### PR TITLE
feat: add mobile-compatible wallet connection flow (closes #12)

### DIFF
--- a/src/components/DepositModal.tsx
+++ b/src/components/DepositModal.tsx
@@ -1,20 +1,17 @@
 import { useState, useEffect } from "react";
-import { X, Fingerprint, CheckCircle2, AlertCircle, ExternalLink } from "lucide-react";
+import { X, Fingerprint, CheckCircle2, AlertCircle, ExternalLink, Smartphone } from "lucide-react";
 import { useApp } from "@/context/AppContext";
-import { isConnected, requestAccess, signTransaction } from "@stellar/freighter-api";
+import { useMobileWallet } from "@/hooks/useMobileWallet";
 import confetti from "canvas-confetti";
 import { supabase } from "@/integrations/supabase/client";
-import { 
-  TransactionBuilder, 
-  Networks, 
-  Operation, 
-  BASE_FEE, 
-  nativeToScVal, 
-  rpc, 
-  Transaction 
+import {
+  TransactionBuilder,
+  Networks,
+  Operation,
+  BASE_FEE,
+  nativeToScVal,
+  rpc,
 } from "@stellar/stellar-sdk";
-
-// Importamos tus constantes (asegúrate de que la ruta sea correcta)
 import { CONTRACT_ID, RPC_URL } from "@/stellar/contracts";
 
 interface Props {
@@ -22,46 +19,48 @@ interface Props {
   onClose: () => void;
 }
 
+// Map raw errors to user-friendly messages
+function friendlyDepositError(msg: string, cancelled: boolean): string {
+  if (cancelled) return "Firma cancelada. Puedes intentarlo de nuevo.";
+  if (msg.includes("Cuenta incorrecta")) return msg; // already friendly
+  if (msg.includes("popup")) return "El popup fue bloqueado. Permite ventanas emergentes e intenta de nuevo.";
+  if (msg.includes("Instala") || msg.includes("not installed")) return "Wallet no disponible. Conecta tu wallet primero.";
+  if (msg.includes("Acceso denegado") || msg.includes("rejected")) return "Acceso denegado. Aprueba la solicitud en tu wallet.";
+  if (msg.includes("insufficient")) return "Saldo insuficiente para cubrir la transacción y las comisiones.";
+  return msg || "Error al procesar el depósito. Intenta de nuevo.";
+}
+
 const DepositModal = ({ open, onClose }: Props) => {
   const { addDeposit, depositsCount, requiredDeposits, isUnlocked, setShowUnlockCelebration } = useApp();
+  const { isMobile, provider, connect, sign } = useMobileWallet();
+
   const [amount, setAmount] = useState("50");
   const [step, setStep] = useState<"input" | "signing" | "success" | "error">("input");
   const [errorMsg, setErrorMsg] = useState("");
   const [txHash, setTxHash] = useState("");
-
-  // 🔐 CANDADO DE SEGURIDAD PARA FREIGHTER
   const [registeredWallet, setRegisteredWallet] = useState<string | null>(null);
 
-  // 📡 Obtenemos la wallet real del usuario desde Supabase al cargar el modal
+  // Fetch the wallet address registered in Supabase for security validation
   useEffect(() => {
-    let isMounted = true;
-
+    let mounted = true;
     const fetchWallet = async () => {
       try {
         const { data: { user } } = await supabase.auth.getUser();
         if (!user) return;
-
         const { data: profile } = await supabase
           .from("profiles")
           .select("wallet_address")
           .eq("user_id", user.id)
           .single();
-
-        if (profile?.wallet_address && isMounted) {
+        if (profile?.wallet_address && mounted) {
           setRegisteredWallet(profile.wallet_address);
         }
-      } catch (error) {
-        console.error("Error obteniendo la wallet registrada:", error);
+      } catch (e) {
+        console.error("Error obteniendo wallet registrada:", e);
       }
     };
-
-    if (open) {
-      fetchWallet();
-    }
-
-    return () => {
-      isMounted = false;
-    };
+    if (open) fetchWallet();
+    return () => { mounted = false; };
   }, [open]);
 
   if (!open) return null;
@@ -86,26 +85,25 @@ const DepositModal = ({ open, onClose }: Props) => {
     setErrorMsg("");
 
     try {
-      // 1. Inicializar Servidor RPC y verificar conexión
       const server = new rpc.Server(RPC_URL);
-      const connected = await isConnected();
-      if (!connected) throw new Error("Instala Freighter para continuar");
 
-      const accessResult = await requestAccess();
-      if (accessResult.error || !accessResult.address) throw new Error("Acceso denegado");
-      
-      const sourcePublicKey = accessResult.address;
+      // 1. Ensure we have a connected wallet address
+      const connectResult = await connect();
+      if (!connectResult.ok) {
+        throw Object.assign(new Error(connectResult.error), { cancelled: connectResult.cancelled });
+      }
+      const sourcePublicKey = connectResult.address;
 
-      // 🛡️ NUEVO CANDADO DE SEGURIDAD
+      // 2. Security: validate against registered wallet
       if (registeredWallet && sourcePublicKey !== registeredWallet) {
-        const shortWallet = `${registeredWallet.substring(0, 4)}...${registeredWallet.substring(52)}`;
-        throw new Error(`Cuenta incorrecta en Freighter. Por favor cambia a tu cuenta registrada: ${shortWallet}`);
+        const short = `${registeredWallet.substring(0, 4)}...${registeredWallet.substring(52)}`;
+        throw new Error(`Cuenta incorrecta. Usa tu cuenta registrada: ${short}`);
       }
 
+      // 3. Fetch account and build transaction
       const account = await server.getAccount(sourcePublicKey);
-      const amountInStroops = BigInt(Math.floor(val * 10000000));
+      const amountInStroops = BigInt(Math.floor(val * 10_000_000));
 
-      // 2. Construir la transacción de invocación
       let transaction = new TransactionBuilder(account, {
         fee: BASE_FEE,
         networkPassphrase: Networks.TESTNET,
@@ -123,66 +121,71 @@ const DepositModal = ({ open, onClose }: Props) => {
         .setTimeout(30)
         .build();
 
-      // 3. Preparar la transacción (Calcula footprint y gas para Soroban)
+      // 4. Prepare (calculates Soroban footprint + gas)
       transaction = await server.prepareTransaction(transaction);
 
-      // 4. Firmar con Freighter
-      const signResult = await signTransaction(transaction.toXDR(), {
-        networkPassphrase: Networks.TESTNET,
-      });
-
-      if (signResult.error || !signResult.signedTxXdr) {
-        throw new Error("Firma rechazada por el usuario");
+      // 5. Sign via the appropriate provider (Freighter on desktop, Albedo on mobile)
+      const signResult = await sign(transaction.toXDR());
+      if (!signResult.ok) {
+        throw Object.assign(new Error(signResult.error), { cancelled: signResult.cancelled });
       }
 
-      // 5. Enviar a la red (Usamos as any para evitar errores estrictos de TS)
-      const transactionToSubmit = TransactionBuilder.fromXDR(signResult.signedTxXdr, Networks.TESTNET);
-      const submitRes = await server.sendTransaction(transactionToSubmit) as any;
+      // 6. Submit
+      const txToSubmit = TransactionBuilder.fromXDR(signResult.signedXdr, Networks.TESTNET);
+      const submitRes = await server.sendTransaction(txToSubmit) as any;
+      const status = (submitRes.status ?? "").toUpperCase();
 
-      // 6. Validar estado (Convertimos a mayúsculas para evitar el error anterior)
-      const currentStatus = submitRes.status ? submitRes.status.toUpperCase() : "";
-
-      if (currentStatus === "PENDING" || currentStatus === "SUCCESS") {
-        setTxHash(submitRes.hash);
-        
-        // Actualizamos el estado local de la app
-        const wasLocked = !isUnlocked;
-        const willUnlock = depositsCount + 1 >= requiredDeposits;
-        addDeposit(val);
-        
-        setStep("success");
-        confetti({ particleCount: 100, spread: 70, origin: { y: 0.65 } });
-
-        if (wasLocked && willUnlock) {
-          setTimeout(() => setShowUnlockCelebration(true), 800);
-        }
-      } else {
-        console.error("Respuesta de la red fallida:", submitRes);
-        throw new Error(submitRes.errorResultXdr || "La transacción fue rechazada por la red");
+      if (status !== "PENDING" && status !== "SUCCESS") {
+        throw new Error(submitRes.errorResultXdr || "La transacción fue rechazada por la red.");
       }
 
+      setTxHash(submitRes.hash);
+
+      const wasLocked = !isUnlocked;
+      const willUnlock = depositsCount + 1 >= requiredDeposits;
+      addDeposit(val);
+      setStep("success");
+      confetti({ particleCount: 100, spread: 70, origin: { y: 0.65 } });
+
+      if (wasLocked && willUnlock) {
+        setTimeout(() => setShowUnlockCelebration(true), 800);
+      }
     } catch (err: any) {
-      console.error("Deposit Error Details:", err);
-      setErrorMsg(err.message || "Error al procesar el depósito");
+      console.error("Deposit error:", err);
+      setErrorMsg(friendlyDepositError(err.message ?? "", !!err.cancelled));
       setStep("error");
     }
   };
 
+  const providerLabel = provider === "albedo" ? "Albedo" : "Freighter";
+
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
-      <div className="absolute inset-0 bg-foreground/40 backdrop-blur-sm" onClick={step === "signing" ? undefined : handleClose} />
+      <div
+        className="absolute inset-0 bg-foreground/40 backdrop-blur-sm"
+        onClick={step === "signing" ? undefined : handleClose}
+      />
       <div className="relative bg-card rounded-t-3xl sm:rounded-2xl w-full max-w-md p-6 pb-8 animate-slide-up z-10">
         {step !== "signing" && (
-          <button onClick={handleClose} className="absolute right-4 top-4 p-2 rounded-full hover:bg-secondary active:scale-95 transition-all">
+          <button
+            onClick={handleClose}
+            className="absolute right-4 top-4 p-2 rounded-full hover:bg-secondary active:scale-95 transition-all"
+          >
             <X className="w-5 h-5 text-muted-foreground" />
           </button>
         )}
 
-        {/* INPUT STEP */}
+        {/* INPUT */}
         {step === "input" && (
           <>
-            <h2 className="text-xl font-bold text-foreground mb-6">Depositar Ganancias</h2>
-            <div className="mb-6">
+            <h2 className="text-xl font-bold text-foreground mb-1">Depositar Ganancias</h2>
+            {isMobile && (
+              <div className="flex items-center gap-1.5 mb-4 text-xs text-muted-foreground">
+                <Smartphone className="w-3.5 h-3.5" />
+                <span>Se firmará con {providerLabel}</span>
+              </div>
+            )}
+            <div className="mb-6 mt-4">
               <label className="text-sm font-medium text-muted-foreground mb-2 block">Monto (XLM)</label>
               <input
                 type="number"
@@ -190,6 +193,7 @@ const DepositModal = ({ open, onClose }: Props) => {
                 onChange={(e) => setAmount(e.target.value)}
                 className="w-full text-3xl font-bold text-foreground bg-secondary rounded-xl px-4 py-4 outline-none focus:ring-2 focus:ring-primary/20 transition-shadow tabular-nums"
                 min="1"
+                inputMode="decimal"
               />
             </div>
 
@@ -212,25 +216,29 @@ const DepositModal = ({ open, onClose }: Props) => {
               className="btn-emerald w-full flex items-center justify-center gap-2 py-4 text-base"
             >
               <Fingerprint className="w-5 h-5" />
-              Confirmar con Freighter
+              Confirmar con {providerLabel}
             </button>
           </>
         )}
 
-        {/* SIGNING STEP */}
+        {/* SIGNING */}
         {step === "signing" && (
           <div className="flex flex-col items-center py-10">
             <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center mb-5">
-              <Fingerprint className="w-8 h-8 text-primary animate-pulse" />
+              {isMobile
+                ? <Smartphone className="w-8 h-8 text-primary animate-pulse" />
+                : <Fingerprint className="w-8 h-8 text-primary animate-pulse" />}
             </div>
             <p className="text-lg font-bold text-foreground mb-1">Preparando contrato...</p>
             <p className="text-sm text-muted-foreground text-center max-w-[260px]">
-              Calculando recursos y esperando confirmación en Freighter.
+              {isMobile
+                ? `Aprueba la transacción en ${providerLabel}.`
+                : `Calculando recursos y esperando confirmación en ${providerLabel}.`}
             </p>
           </div>
         )}
 
-        {/* SUCCESS STEP */}
+        {/* SUCCESS */}
         {step === "success" && (
           <div className="flex flex-col items-center py-8 animate-scale-up">
             <div className="w-20 h-20 rounded-full bg-primary/10 flex items-center justify-center mb-5">
@@ -240,7 +248,6 @@ const DepositModal = ({ open, onClose }: Props) => {
             <p className="text-sm text-muted-foreground mb-4">
               Se depositaron <span className="font-bold text-foreground">{amount} XLM</span>
             </p>
-
             {txHash && (
               <a
                 href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
@@ -252,7 +259,6 @@ const DepositModal = ({ open, onClose }: Props) => {
                 Ver en el explorador
               </a>
             )}
-
             <button
               onClick={handleClose}
               className="w-full rounded-xl bg-primary text-primary-foreground py-3 text-sm font-semibold shadow-sm hover:bg-primary/90 active:scale-[0.97] transition-all"
@@ -262,7 +268,7 @@ const DepositModal = ({ open, onClose }: Props) => {
           </div>
         )}
 
-        {/* ERROR STEP */}
+        {/* ERROR */}
         {step === "error" && (
           <div className="flex flex-col items-center py-8 animate-scale-up">
             <div className="w-20 h-20 rounded-full bg-destructive/10 flex items-center justify-center mb-5">
@@ -270,7 +276,6 @@ const DepositModal = ({ open, onClose }: Props) => {
             </div>
             <p className="text-lg font-bold text-foreground mb-2">Error en el depósito</p>
             <p className="text-sm text-muted-foreground text-center max-w-[280px] mb-6">{errorMsg}</p>
-
             <div className="w-full flex gap-3">
               <button
                 onClick={handleClose}

--- a/src/components/WalletSetupModal.tsx
+++ b/src/components/WalletSetupModal.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/hooks/useAuth";
-import { Wallet, Loader2, CheckCircle2, AlertCircle } from "lucide-react";
-import { requestAccess, isConnected } from "@stellar/freighter-api";
+import { Wallet, Loader2, CheckCircle2, AlertCircle, Smartphone, ExternalLink } from "lucide-react";
+import { useMobileWallet } from "@/hooks/useMobileWallet";
 
 interface WalletSetupModalProps {
   onComplete: () => void;
@@ -10,43 +10,40 @@ interface WalletSetupModalProps {
 
 const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
   const { user } = useAuth();
+  const { isMobile, isFreighterReady, connect } = useMobileWallet();
+
   const [saving, setSaving] = useState(false);
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
   const [address, setAddress] = useState<string | null>(null);
+  const [walletProvider, setWalletProvider] = useState<"freighter" | "albedo" | null>(null);
 
   const handleConnect = async () => {
     setConnecting(true);
     setError(null);
 
-    try {
-      const connected = await isConnected();
-      if (!connected) {
-        setError("Freighter no está instalado. Instálalo desde freighter.app");
-        setConnecting(false);
-        return;
-      }
-
-      const accessObj = await requestAccess();
-
-      if (accessObj.error) {
-        setError("Conexión rechazada. Intenta de nuevo.");
-        setConnecting(false);
-        return;
-      }
-
-      const publicKey = accessObj.address;
-      if (!publicKey) {
-        setError("No se pudo obtener la dirección. Intenta de nuevo.");
-        setConnecting(false);
-        return;
-      }
-
-      setAddress(publicKey);
-    } catch {
-      setError("Error al conectar con Freighter. ¿Está instalada la extensión?");
+    // On desktop without Freighter, guide user before attempting
+    if (!isMobile && !isFreighterReady) {
+      setError("Freighter no está instalado. Instálalo desde freighter.app o usa Albedo.");
+      setConnecting(false);
+      return;
     }
+
+    const result = await connect();
+
+    if (!result.ok) {
+      setError(
+        result.cancelled
+          ? "Conexión cancelada. Puedes intentarlo de nuevo."
+          : result.error
+      );
+      setConnecting(false);
+      return;
+    }
+
+    setAddress(result.address);
+    setWalletProvider(result.provider);
     setConnecting(false);
   };
 
@@ -66,12 +63,20 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
       return;
     }
 
+    // Persist provider choice for future signing
+    if (walletProvider) {
+      localStorage.setItem("vinculo_wallet_provider", walletProvider);
+    }
+    localStorage.setItem("vinculo_wallet", address);
+
     setDone(true);
     setTimeout(onComplete, 1200);
   };
 
   const truncate = (addr: string) =>
     addr.length > 16 ? `${addr.slice(0, 8)}...${addr.slice(-6)}` : addr;
+
+  const providerLabel = isMobile ? "Albedo" : isFreighterReady ? "Freighter" : "Albedo";
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/40 backdrop-blur-sm px-6">
@@ -88,11 +93,13 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
           <>
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
-                <Wallet className="w-5 h-5 text-primary" />
+                {isMobile ? <Smartphone className="w-5 h-5 text-primary" /> : <Wallet className="w-5 h-5 text-primary" />}
               </div>
               <div>
                 <h2 className="text-lg font-bold text-foreground leading-tight">Conecta tu wallet</h2>
-                <p className="text-xs text-muted-foreground">Usa la extensión Freighter</p>
+                <p className="text-xs text-muted-foreground">
+                  {isMobile ? "Vía Albedo (web wallet)" : `Vía ${providerLabel}`}
+                </p>
               </div>
             </div>
 
@@ -100,6 +107,11 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
               <div className="bg-secondary rounded-xl px-4 py-3">
                 <p className="text-xs text-muted-foreground mb-0.5">Dirección Stellar</p>
                 <p className="text-sm font-mono font-medium text-foreground">{truncate(address)}</p>
+                {walletProvider && (
+                  <p className="text-[10px] text-muted-foreground mt-1 uppercase tracking-wide">
+                    via {walletProvider}
+                  </p>
+                )}
               </div>
             ) : (
               <button
@@ -113,10 +125,14 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
                   <Wallet className="w-6 h-6 text-primary" />
                 )}
                 <span className="text-sm font-semibold text-foreground">
-                  {connecting ? "Conectando..." : "Conectar Freighter"}
+                  {connecting ? "Conectando..." : `Conectar con ${providerLabel}`}
                 </span>
                 <span className="text-xs text-muted-foreground">
-                  Se abrirá la extensión del navegador
+                  {isMobile
+                    ? "Se abrirá Albedo en tu navegador"
+                    : isFreighterReady
+                    ? "Se abrirá la extensión Freighter"
+                    : "Se abrirá Albedo (no requiere extensión)"}
                 </span>
               </button>
             )}
@@ -146,14 +162,17 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
               )}
             </div>
 
-            <a
-              href="https://www.freighter.app/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block text-center text-xs text-primary hover:underline"
-            >
-              ¿No tienes Freighter? Descárgala aquí →
-            </a>
+            {!isMobile && (
+              <a
+                href="https://www.freighter.app/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center gap-1 text-xs text-primary hover:underline"
+              >
+                <ExternalLink className="w-3 h-3" />
+                ¿No tienes Freighter? Descárgala aquí
+              </a>
+            )}
           </>
         )}
       </div>

--- a/src/hooks/useMobileWallet.ts
+++ b/src/hooks/useMobileWallet.ts
@@ -1,0 +1,69 @@
+/**
+ * useMobileWallet
+ *
+ * Thin React hook that wraps the connector abstraction and exposes:
+ *  - connect()        → get public key (auto-picks provider)
+ *  - sign(xdr)        → sign a transaction XDR
+ *  - isMobile         → boolean
+ *  - provider         → "freighter" | "albedo"
+ *  - isFreighterReady → boolean (extension detected)
+ */
+
+import { useState, useEffect } from "react";
+import {
+  connectWallet,
+  signTransactionXdr,
+  isMobileBrowser,
+  isFreighterAvailable,
+  getSavedProvider,
+  saveProvider,
+  type ConnectResult,
+  type SignResult,
+} from "@/lib/mobileWalletConnectors";
+
+export function useMobileWallet() {
+  const [isMobile] = useState<boolean>(() => isMobileBrowser());
+  const [freighterReady, setFreighterReady] = useState<boolean>(false);
+  const [provider, setProvider] = useState<"freighter" | "albedo">(
+    getSavedProvider
+  );
+
+  // Poll for Freighter extension on desktop (it may inject after page load)
+  useEffect(() => {
+    if (isMobile) return;
+
+    const check = () => {
+      const available = isFreighterAvailable();
+      setFreighterReady(available);
+      // If extension just appeared and user hasn't explicitly chosen albedo, switch
+      if (available && getSavedProvider() !== "albedo") {
+        setProvider("freighter");
+      }
+    };
+
+    check();
+    const id = setInterval(check, 1000);
+    return () => clearInterval(id);
+  }, [isMobile]);
+
+  const connect = async (): Promise<ConnectResult> => {
+    const result = await connectWallet();
+    if (result.ok) {
+      saveProvider(result.provider);
+      setProvider(result.provider);
+    }
+    return result;
+  };
+
+  const sign = async (xdr: string): Promise<SignResult> => {
+    return signTransactionXdr(xdr, provider);
+  };
+
+  return {
+    isMobile,
+    provider,
+    isFreighterReady: freighterReady,
+    connect,
+    sign,
+  };
+}

--- a/src/lib/mobileWalletConnectors.ts
+++ b/src/lib/mobileWalletConnectors.ts
@@ -1,0 +1,170 @@
+/**
+ * Mobile Wallet Connector Abstraction
+ *
+ * Strategy:
+ * - Desktop: Freighter browser extension (existing flow, unchanged)
+ * - Mobile:  Albedo web wallet (works in any mobile browser via popup/redirect,
+ *            already in package.json as @albedo-link/intent)
+ *
+ * Albedo is a standards-based Stellar web wallet that requires no app install
+ * and supports both signing and public-key retrieval via a popup or redirect.
+ * It is the safest non-lock-in choice: if a better mobile connector emerges
+ * (e.g. WalletConnect for Stellar), only this file needs updating.
+ */
+
+import albedo from "@albedo-link/intent";
+import * as FreighterAPI from "@stellar/freighter-api";
+import { Networks } from "@stellar/stellar-sdk";
+
+// ─── Environment detection ────────────────────────────────────────────────────
+
+export function isMobileBrowser(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Android|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop/i.test(
+    navigator.userAgent
+  );
+}
+
+export function isFreighterAvailable(): boolean {
+  // window.freighter is injected by the extension; on mobile it will never exist
+  return typeof window !== "undefined" && !!(window as any).freighter;
+}
+
+// ─── Unified result types ─────────────────────────────────────────────────────
+
+export type ConnectResult =
+  | { ok: true; address: string; provider: "freighter" | "albedo" }
+  | { ok: false; cancelled: boolean; error: string };
+
+export type SignResult =
+  | { ok: true; signedXdr: string }
+  | { ok: false; cancelled: boolean; error: string };
+
+// ─── Connect (get public key) ─────────────────────────────────────────────────
+
+export async function connectWallet(): Promise<ConnectResult> {
+  if (!isMobileBrowser() && isFreighterAvailable()) {
+    return connectFreighter();
+  }
+  return connectAlbedo();
+}
+
+async function connectFreighter(): Promise<ConnectResult> {
+  try {
+    const res = await FreighterAPI.requestAccess();
+    if (res.error) {
+      const cancelled =
+        res.error.includes("User declined") ||
+        res.error.includes("User rejected") ||
+        res.error.includes("rejected");
+      return { ok: false, cancelled, error: res.error };
+    }
+    if (!res.address) {
+      return { ok: false, cancelled: false, error: "No se obtuvo la dirección pública." };
+    }
+    return { ok: true, address: res.address, provider: "freighter" };
+  } catch (err: any) {
+    return { ok: false, cancelled: false, error: err?.message ?? "Error desconocido con Freighter." };
+  }
+}
+
+async function connectAlbedo(): Promise<ConnectResult> {
+  try {
+    // albedo.publicKey() opens a popup/redirect and resolves with the user's
+    // public key once they approve. On mobile it uses a redirect flow.
+    const res = await albedo.publicKey({ require_existing: false });
+    if (!res.pubkey) {
+      return { ok: false, cancelled: false, error: "Albedo no devolvió una dirección." };
+    }
+    return { ok: true, address: res.pubkey, provider: "albedo" };
+  } catch (err: any) {
+    const msg: string = err?.message ?? String(err);
+    // Albedo throws "Operation rejected" when the user closes the popup
+    const cancelled =
+      msg.toLowerCase().includes("rejected") ||
+      msg.toLowerCase().includes("cancel") ||
+      msg.toLowerCase().includes("closed");
+    return {
+      ok: false,
+      cancelled,
+      error: cancelled
+        ? "Conexión cancelada. Puedes intentarlo de nuevo."
+        : `Error al conectar con Albedo: ${msg}`,
+    };
+  }
+}
+
+// ─── Sign transaction XDR ─────────────────────────────────────────────────────
+
+export async function signTransactionXdr(
+  xdr: string,
+  provider: "freighter" | "albedo"
+): Promise<SignResult> {
+  if (provider === "freighter") {
+    return signWithFreighter(xdr);
+  }
+  return signWithAlbedo(xdr);
+}
+
+async function signWithFreighter(xdr: string): Promise<SignResult> {
+  try {
+    const res = await FreighterAPI.signTransaction(xdr, {
+      networkPassphrase: Networks.TESTNET,
+    });
+    if (res.error) {
+      const cancelled =
+        res.error.includes("User declined") ||
+        res.error.includes("User rejected") ||
+        res.error.includes("rejected");
+      return { ok: false, cancelled, error: res.error };
+    }
+    if (!res.signedTxXdr) {
+      return { ok: false, cancelled: false, error: "Freighter no devolvió la transacción firmada." };
+    }
+    return { ok: true, signedXdr: res.signedTxXdr };
+  } catch (err: any) {
+    return { ok: false, cancelled: false, error: err?.message ?? "Error al firmar con Freighter." };
+  }
+}
+
+async function signWithAlbedo(xdr: string): Promise<SignResult> {
+  try {
+    const res = await albedo.tx({
+      xdr,
+      network: "testnet",
+      submit: false, // we submit ourselves for consistency
+    });
+    if (!res.signed_envelope_xdr) {
+      return { ok: false, cancelled: false, error: "Albedo no devolvió la transacción firmada." };
+    }
+    return { ok: true, signedXdr: res.signed_envelope_xdr };
+  } catch (err: any) {
+    const msg: string = err?.message ?? String(err);
+    const cancelled =
+      msg.toLowerCase().includes("rejected") ||
+      msg.toLowerCase().includes("cancel") ||
+      msg.toLowerCase().includes("closed");
+    return {
+      ok: false,
+      cancelled,
+      error: cancelled
+        ? "Firma cancelada. Puedes intentarlo de nuevo."
+        : `Error al firmar con Albedo: ${msg}`,
+    };
+  }
+}
+
+// ─── Persist / retrieve provider choice ──────────────────────────────────────
+
+const PROVIDER_KEY = "vinculo_wallet_provider";
+
+export function saveProvider(provider: "freighter" | "albedo"): void {
+  localStorage.setItem(PROVIDER_KEY, provider);
+}
+
+export function getSavedProvider(): "freighter" | "albedo" {
+  const saved = localStorage.getItem(PROVIDER_KEY);
+  if (saved === "freighter" || saved === "albedo") return saved;
+  // Default: if on mobile default to albedo, else freighter
+  return isMobileBrowser() ? "albedo" : "freighter";
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,67 +1,42 @@
-import { useState, useEffect } from "react";
-import { Loader2, Wallet, AlertCircle, ExternalLink } from "lucide-react";
+import { useState } from "react";
+import { Loader2, Wallet, AlertCircle, ExternalLink, Smartphone } from "lucide-react";
 import logoVin from "@/assets/logo-vin.png";
-import * as FreighterAPI from "@stellar/freighter-api"; 
+import { useMobileWallet } from "@/hooks/useMobileWallet";
+
+// Human-readable error messages
+function friendlyError(raw: string, cancelled: boolean): string {
+  if (cancelled) return "Conexión cancelada. Puedes intentarlo de nuevo cuando quieras.";
+  if (raw.toLowerCase().includes("popup")) return "El popup fue bloqueado. Permite ventanas emergentes para este sitio e intenta de nuevo.";
+  return "Error de conexión. Verifica que tu wallet esté desbloqueada e intenta de nuevo.";
+}
 
 const Login = () => {
+  const { isMobile, isFreighterReady, provider, connect } = useMobileWallet();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  
-  // Estado único: ¿La extensión de Chrome/Brave/Edge está lista?
-  const [isExtensionInstalled, setIsExtensionInstalled] = useState(false);
-
-  useEffect(() => {
-    const checkExtension = async () => {
-      try {
-        const { isConnected } = await FreighterAPI.isConnected();
-        if (isConnected) {
-          setIsExtensionInstalled(true);
-        }
-      } catch (e) {
-        // Ignoramos errores silenciosamente durante la detección
-      }
-    };
-
-    checkExtension();
-    
-    // Polling ligero de 1 segundo por si la extensión tarda en inyectarse al recargar la página
-    const interval = setInterval(checkExtension, 1000);
-    return () => clearInterval(interval);
-  }, []);
 
   const connectWallet = async () => {
     setLoading(true);
     setError(null);
 
-    try {
-      // Método oficial y directo para PC
-      const response = await FreighterAPI.requestAccess();
-      
-      if (response.error) {
-        throw new Error(response.error);
-      }
+    const result = await connect();
 
-      if (response.address) {
-        localStorage.setItem("vinculo_wallet", response.address);
-        localStorage.setItem("vinculo_onboarded", "1");
-        
-        // Pequeño tiempo de gracia para que React Router o el navegador asimilen el cambio
-        setTimeout(() => { window.location.href = "/"; }, 200);
-      } else {
-        throw new Error("No se obtuvo la llave pública.");
-      }
-    } catch (err: any) {
+    if (!result.ok) {
       setLoading(false);
-      const msg = err.message || "";
-      
-      // Manejo de rechazos del usuario vs errores técnicos
-      if (msg.includes("User declined") || msg.includes("User rejected")) {
-        setError("Conexión rechazada. Debes aprobar la solicitud en Freighter.");
-      } else {
-        setError("Error de conexión. Verifica que tu extensión esté desbloqueada.");
-      }
+      setError(friendlyError(result.error, result.cancelled));
+      return;
     }
+
+    localStorage.setItem("vinculo_wallet", result.address);
+    localStorage.setItem("vinculo_onboarded", "1");
+    localStorage.setItem("vinculo_wallet_provider", result.provider);
+
+    // Small grace period for React Router to pick up the change
+    setTimeout(() => { window.location.href = "/"; }, 200);
   };
+
+  // ── Desktop: Freighter not installed ──────────────────────────────────────
+  const showFreighterInstallPrompt = !isMobile && !isFreighterReady;
 
   return (
     <div className="min-h-screen bg-background flex flex-col items-center justify-center px-6">
@@ -72,40 +47,74 @@ const Login = () => {
       </div>
 
       <div className="w-full max-w-sm space-y-4">
-        
-        {isExtensionInstalled ? (
-          /* ESTADO A: Extensión Detectada -> Botón de Conectar */
+
+        {/* ── Mobile: Albedo web wallet ──────────────────────────────────── */}
+        {isMobile && (
+          <div className="space-y-4 animate-in fade-in">
+            <div className="p-4 rounded-xl bg-primary/5 border border-primary/15 text-center">
+              <Smartphone className="w-5 h-5 text-primary mx-auto mb-1" />
+              <p className="text-sm font-bold text-foreground mb-0.5">Wallet móvil</p>
+              <p className="text-xs text-muted-foreground">
+                Usaremos Albedo, una wallet web de Stellar que funciona directamente en tu navegador — sin instalar nada.
+              </p>
+            </div>
+
+            <button
+              onClick={connectWallet}
+              disabled={loading}
+              className="w-full flex items-center justify-center gap-3 rounded-2xl bg-primary text-primary-foreground px-5 py-4 text-sm font-bold shadow-lg shadow-primary/20 active:scale-[0.98] transition-all disabled:opacity-60"
+            >
+              {loading ? <Loader2 className="h-5 w-5 animate-spin" /> : <Wallet className="h-5 w-5" />}
+              {loading ? "Abriendo Albedo..." : "Conectar con Albedo"}
+            </button>
+          </div>
+        )}
+
+        {/* ── Desktop: Freighter ready ───────────────────────────────────── */}
+        {!isMobile && isFreighterReady && (
           <button
             onClick={connectWallet}
             disabled={loading}
-            className="w-full flex items-center justify-center gap-3 rounded-2xl bg-primary text-primary-foreground px-5 py-4 text-sm font-bold shadow-lg shadow-primary/20 active:scale-[0.98] transition-all"
+            className="w-full flex items-center justify-center gap-3 rounded-2xl bg-primary text-primary-foreground px-5 py-4 text-sm font-bold shadow-lg shadow-primary/20 active:scale-[0.98] transition-all disabled:opacity-60"
           >
             {loading ? <Loader2 className="h-5 w-5 animate-spin" /> : <Wallet className="h-5 w-5" />}
-            {loading ? "Conectando..." : "Conectar Wallet"}
+            {loading ? "Conectando..." : "Conectar con Freighter"}
           </button>
-        ) : (
-          /* ESTADO B: No hay Extensión -> Call to action para descargarla */
+        )}
+
+        {/* ── Desktop: Freighter not installed ──────────────────────────── */}
+        {showFreighterInstallPrompt && (
           <div className="space-y-4 animate-in fade-in">
             <div className="p-4 rounded-xl bg-amber-500/10 border border-amber-500/20 text-center">
               <p className="text-sm font-bold text-amber-700 mb-1">Freighter no detectado</p>
               <p className="text-xs text-amber-800/80">
-                Para usar Vínculo, necesitas la extensión de billetera de Stellar.
+                Para usar Vínculo en escritorio necesitas la extensión Freighter, o puedes conectarte con Albedo directamente.
               </p>
             </div>
-            
-            <a 
-              href="https://www.freighter.app/" 
-              target="_blank" 
+
+            <a
+              href="https://www.freighter.app/"
+              target="_blank"
               rel="noreferrer"
               className="w-full flex items-center justify-center gap-2 rounded-2xl bg-secondary text-foreground px-5 py-4 text-sm font-bold active:scale-[0.98] transition-all hover:bg-secondary/80"
             >
               <ExternalLink className="w-4 h-4" />
               Instalar Freighter
             </a>
+
+            {/* Albedo as desktop fallback too */}
+            <button
+              onClick={connectWallet}
+              disabled={loading}
+              className="w-full flex items-center justify-center gap-2 rounded-2xl border border-border bg-card text-foreground px-5 py-3.5 text-sm font-semibold active:scale-[0.98] transition-all hover:bg-secondary/60 disabled:opacity-60"
+            >
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Wallet className="h-4 w-4" />}
+              {loading ? "Abriendo Albedo..." : "Continuar con Albedo (web)"}
+            </button>
           </div>
         )}
 
-        {/* Notificación de Error */}
+        {/* ── Error notification ─────────────────────────────────────────── */}
         {error && (
           <div className="p-3 rounded-xl bg-destructive/10 border border-destructive/20 text-destructive text-[11px] font-bold uppercase text-center animate-shake mt-4">
             <AlertCircle className="w-4 h-4 inline mr-2 mb-0.5" />

--- a/src/pages/Retiros.tsx
+++ b/src/pages/Retiros.tsx
@@ -1,13 +1,13 @@
 import { useState, useEffect, useCallback } from "react";
 import {
   ArrowDownToLine, Fingerprint, CheckCircle2,
-  X, Lock, TrendingUp, Clock, Sparkles, Unlock
+  X, Lock, TrendingUp, Clock, Sparkles, Unlock, Smartphone
 } from "lucide-react";
 import { useApp } from "@/context/AppContext";
-import { isConnected, requestAccess, signTransaction } from "@stellar/freighter-api";
 import confetti from "canvas-confetti";
 import BottomNav from "@/components/BottomNav";
 import logoVin from "@/assets/logo-vin.png";
+import { useMobileWallet } from "@/hooks/useMobileWallet";
 
 import { TransactionBuilder, Networks, Operation, BASE_FEE, nativeToScVal, rpc } from "@stellar/stellar-sdk";
 import { CONTRACT_ID, RPC_URL } from "@/stellar/contracts";
@@ -22,7 +22,8 @@ const STAKING_OPTIONS = [
 
 const Retiros = () => {
   const { addWithdrawal } = useApp();
-  
+  const { isMobile, provider, connect, sign } = useMobileWallet();
+
   const [realBalance, setRealBalance] = useState<number>(0);
   const [walletAddress, setWalletAddress] = useState<string | null>(null);
   
@@ -46,13 +47,18 @@ const Retiros = () => {
   useEffect(() => {
     const initWallet = async () => {
       try {
-        if (await isConnected()) {
-          const access = await requestAccess();
-          if (access.address) setWalletAddress(access.address);
+        // Prefer saved wallet from localStorage to avoid prompting on page load
+        const saved = localStorage.getItem("vinculo_wallet");
+        if (saved) {
+          setWalletAddress(saved);
+        } else {
+          const result = await connect();
+          if (result.ok) setWalletAddress(result.address);
         }
-      } catch (error) { console.error("Error conectando Freighter:", error); }
+      } catch (error) { console.error("Error inicializando wallet:", error); }
     };
     initWallet();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const loadData = useCallback(async (address: string) => {
@@ -111,27 +117,46 @@ const Retiros = () => {
   const processContractCall = async (functionName: string, args: any[], successStep: any) => {
     try {
       const server = new rpc.Server(RPC_URL);
-      const connected = await isConnected();
-      if (!connected) throw new Error("Instala Freighter");
 
-      const accessResult = await requestAccess();
-      if (accessResult.error || !accessResult.address) throw new Error("Acceso denegado");
-      
-      const account = await server.getAccount(accessResult.address);
-      
+      // Resolve wallet address — prefer cached, otherwise prompt
+      let sourceAddress = walletAddress;
+      if (!sourceAddress) {
+        const connectResult = await connect();
+        if (!connectResult.ok) {
+          const msg = connectResult.cancelled
+            ? "Conexión cancelada. Intenta de nuevo."
+            : connectResult.error;
+          throw new Error(msg);
+        }
+        sourceAddress = connectResult.address;
+        setWalletAddress(sourceAddress);
+      }
+
+      const account = await server.getAccount(sourceAddress);
+
       let transaction = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: Networks.TESTNET })
         .addOperation(Operation.invokeContractFunction({ contract: CONTRACT_ID, function: functionName, args }))
         .setTimeout(30).build();
 
       transaction = await server.prepareTransaction(transaction);
-      const signResult = await signTransaction(transaction.toXDR(), { networkPassphrase: Networks.TESTNET });
-      if (signResult.error || !signResult.signedTxXdr) throw new Error("Firma rechazada");
 
-      const txToSubmit = TransactionBuilder.fromXDR(signResult.signedTxXdr, Networks.TESTNET);
+      // Sign via the correct provider (Freighter desktop / Albedo mobile)
+      const signResult = await sign(transaction.toXDR());
+      if (!signResult.ok) {
+        const msg = signResult.cancelled
+          ? "Firma cancelada. Puedes intentarlo de nuevo."
+          : signResult.error;
+        throw new Error(msg);
+      }
+
+      const txToSubmit = TransactionBuilder.fromXDR(signResult.signedXdr, Networks.TESTNET);
       const submitRes = await server.sendTransaction(txToSubmit) as any;
-      const currentStatus = submitRes.status ? submitRes.status.toUpperCase() : "";
-      if (currentStatus !== "PENDING" && currentStatus !== "SUCCESS") throw new Error("Rechazada por la red");
+      const currentStatus = (submitRes.status ?? "").toUpperCase();
+      if (currentStatus !== "PENDING" && currentStatus !== "SUCCESS") {
+        throw new Error("Transacción rechazada por la red.");
+      }
 
+      // Poll until final status
       let txStatus = currentStatus;
       while (txStatus === "PENDING" || txStatus === "NOT_FOUND") {
         await new Promise(resolve => setTimeout(resolve, 2000));
@@ -141,17 +166,15 @@ const Retiros = () => {
 
       if (txStatus === "SUCCESS") {
         if (walletAddress) loadData(walletAddress);
-        
         if (functionName === "withdraw") {
           addWithdrawal(parseFloat(amount), submitRes.hash);
           setStep("success");
         } else {
           setStakeStep(successStep);
         }
-        
         confetti({ particleCount: 100, spread: 70, origin: { y: 0.65 } });
       } else {
-        throw new Error("Transacción fallida en el contrato");
+        throw new Error("Transacción fallida en el contrato.");
       }
     } catch (err: any) {
       console.error(err);
@@ -335,7 +358,15 @@ const Retiros = () => {
             )}
             
             {step === "signing" && (
-              <div className="flex flex-col items-center py-10"><Fingerprint className="w-12 h-12 text-primary animate-pulse mb-4" /><p className="font-bold">Procesando...</p></div>
+              <div className="flex flex-col items-center py-10">
+                {isMobile
+                  ? <Smartphone className="w-12 h-12 text-primary animate-pulse mb-4" />
+                  : <Fingerprint className="w-12 h-12 text-primary animate-pulse mb-4" />}
+                <p className="font-bold">Procesando...</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {isMobile ? `Aprueba en ${provider === "albedo" ? "Albedo" : "tu wallet"}` : "Confirma en Freighter"}
+                </p>
+              </div>
             )}
             
             {step === "success" && (
@@ -370,9 +401,13 @@ const Retiros = () => {
 
             {(stakeStep === "signing" || stakeStep === "unstaking") && (
               <div className="flex flex-col items-center py-10">
-                <Lock className="w-12 h-12 text-accent animate-pulse mb-4" />
+                {isMobile
+                  ? <Smartphone className="w-12 h-12 text-accent animate-pulse mb-4" />
+                  : <Lock className="w-12 h-12 text-accent animate-pulse mb-4" />}
                 <p className="font-bold">Procesando en Soroban...</p>
-                <p className="text-xs text-muted-foreground mt-2">Confirma en Freighter</p>
+                <p className="text-xs text-muted-foreground mt-2">
+                  {isMobile ? `Aprueba en ${provider === "albedo" ? "Albedo" : "tu wallet"}` : "Confirma en Freighter"}
+                </p>
               </div>
             )}
 


### PR DESCRIPTION
Closes #12 

- Add mobileWalletConnectors.ts abstraction layer (Freighter desktop / Albedo mobile)
- Add useMobileWallet hook with provider detection and persistence
- Update Login, WalletSetupModal, DepositModal, Retiros to use unified connector
- Explicit error handling for cancellation, unavailable provider, popup blocked
- Mobile signing path via Albedo (no install required, works in any mobile browser)
- Freighter remains default on desktop; Albedo as fallback when extension missing