### PR TITLE
docs: add architecture overview and core flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ The project uses the following variables:
 1. Use `PORT=3000` if you need a predictable local port.
 2. If your environment already uses another port, you can change it.
 
+## Architecture
+
+Vyn has four layers: a React frontend, Vercel serverless API functions, Supabase for auth and profiles, and three Soroban smart contracts on Stellar Testnet.
+
+- [Architecture overview](docs/architecture.md) — layers, components, contracts, and where to make common changes.
+- [Core flows](docs/flows.md) — step-by-step walkthroughs of auth, deposit, scoring/minting, credit, and loan flows.
+
 ## Notes For Collaborators
 
 - Do not commit `.env.local`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,159 @@
+# Architecture
+
+## Overview
+
+Vyn is a DeFi savings and credit app built on Stellar/Soroban. It has four layers:
+
+```
+Browser (React)
+    │
+    ├── Supabase          — email auth + user profiles
+    ├── Vercel API        — serverless functions (scoring, minting, credit)
+    └── Stellar Testnet   — three Soroban smart contracts
+```
+
+---
+
+## Layer 1 — Frontend
+
+**Stack:** Vite · React · TypeScript · Tailwind CSS  
+**Entry:** `src/main.tsx` → `src/App.tsx`
+
+### Routing (`src/App.tsx`)
+
+| Path | Page | Guards |
+|---|---|---|
+| `/login` | `Login` | public |
+| `/bienvenida` | `Onboarding` | `RequireWallet` |
+| `/` | `Index` | `RequireWallet` + `RequireOnboarding` |
+| `/historial` | `Historial` | `RequireWallet` + `RequireOnboarding` |
+| `/perfil` | `Perfil` | `RequireWallet` + `RequireOnboarding` |
+| `/retiros` | `Retiros` | `RequireWallet` + `RequireOnboarding` |
+| `/notificaciones` | `Notificaciones` | `RequireWallet` + `RequireOnboarding` |
+| `/ayuda` | `Ayuda` | `RequireWallet` + `RequireOnboarding` |
+
+**Guards:**
+- `RequireWallet` — redirects to `/login` if `localStorage.vinculo_wallet` is absent.
+- `RequireOnboarding` — redirects to `/bienvenida` if `localStorage.vinculo_onboarded !== "1"`.
+- `WalletGate` — shows `WalletSetupModal` if the Supabase profile has no `wallet_address`.
+
+### State (`src/context/AppContext.tsx`)
+
+In-memory React context. Tracks deposits, withdrawals, stakes, and credit state for the current session. Not persisted to a database — on-chain data is the source of truth.
+
+| Action | Effect |
+|---|---|
+| `addDeposit(amount)` | Appends deposit, increments counter, triggers unlock celebration |
+| `withdrawCredit()` | Sets `creditWithdrawn = true` |
+| `addWithdrawal(amount, txHash)` | Appends withdrawal, decrements balance |
+| `addStake(amount, months)` | Appends stake position with APY |
+
+### Key components
+
+| Component | Responsibility |
+|---|---|
+| `BalanceCard` | Displays on-chain staking balance via `fetchContractBalance` |
+| `ProgressRing` | Visual progress toward next tier |
+| `CreditSection` | Polls `/api/get-available-credit`, handles loan request and repayment |
+| `DepositModal` | Freighter-signed deposit to `staking_pool` contract |
+| `WalletSetupModal` | Links Freighter wallet to Supabase profile |
+| `NFTModal` | Shows NFT tier image and metadata |
+
+### Stellar helpers (`src/stellar/`)
+
+| File | Purpose |
+|---|---|
+| `contracts.ts` | Exports `CONTRACT_ID` (staking_pool) and `RPC_URL` |
+| `queries.ts` | `fetchContractBalance(address)` and `fetchStakeInfo(address)` — read-only Soroban simulations |
+
+### Hooks
+
+| Hook | Purpose |
+|---|---|
+| `useAuth` | Wraps Supabase auth state (`user`, `session`, `loading`, `signOut`) |
+| `useWallet` | Reads `vinculo_wallet` from localStorage, provides `shortWallet` and `disconnect` |
+
+---
+
+## Layer 2 — Serverless API
+
+Deployed as Vercel serverless functions. Routes are defined in `vercel.json`.
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `POST /api/calculate-score` | POST | Computes reputation score from Horizon transaction history |
+| `POST /api/get-available-credit` | POST | Reads NFT tier from `vinculo_sbt` contract, returns credit limit |
+| `POST /api/evaluate-and-mint` | POST | Calls `calculate-score`, then mints NFT via `vinculo_sbt.mint()` |
+| `GET /api/get-user-data` | GET | Reads staking balance from `staking_pool`, derives a legacy tier |
+
+All functions set permissive CORS headers and handle `OPTIONS` preflight.
+
+---
+
+## Layer 3 — Supabase
+
+**Auth:** Supabase email/password. A `handle_new_user` trigger auto-creates a `profiles` row on signup.
+
+**Table: `profiles`**
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | UUID | PK |
+| `user_id` | UUID | FK → `auth.users` |
+| `display_name` | TEXT | |
+| `avatar_url` | TEXT | |
+| `wallet_address` | TEXT | Set by `WalletSetupModal` after Freighter connection |
+
+Row-level security is enabled; users can only read and write their own row.
+
+---
+
+## Layer 4 — Soroban Contracts
+
+Source in `backend/contracts/`. All deployed to Stellar Testnet.
+
+| Contract | Env var | Responsibility |
+|---|---|---|
+| `staking_pool` | `CONTRACT_ID` (hardcoded) | Accepts XLM deposits, tracks balances and stake positions |
+| `vinculo_sbt` | `NFT_CONTRACT_ID` | Mints and stores SBT/NFT tiers per wallet address |
+| `vinculo_lending` | `VITE_LENDING_CONTRACT_ID` | Issues and tracks loans (`request_loan`, `repay`) |
+
+**Key functions called by the app:**
+
+| Contract | Function | Called from |
+|---|---|---|
+| `staking_pool` | `deposit` | `DepositModal` (Freighter-signed) |
+| `staking_pool` | `get_balance` | `queries.ts`, `api/get-user-data.js` |
+| `staking_pool` | `get_stake` | `queries.ts` |
+| `vinculo_sbt` | `mint` | `api/evaluate-and-mint.js` (admin-signed) |
+| `vinculo_sbt` | `get_tier` | `api/get-available-credit.js` (simulated) |
+| `vinculo_lending` | `request_loan` | `CreditSection` (Freighter-signed) |
+| `vinculo_lending` | `repay` | `CreditSection` (Freighter-signed) |
+
+---
+
+## Tier System
+
+| Tier | Name | Score threshold | Credit limit |
+|---|---|---|---|
+| 0 | Bronce | < 50 | 0 XLM (locked) |
+| 1 | Plata | ≥ 50 | 300 XLM |
+| 2 | Oro | ≥ 150 | 600 XLM |
+| 3 | Diamante | ≥ 500 | 1 500 XLM |
+| 4 | Platino | ≥ 1 000 | 5 000 XLM |
+
+The tier is stored on-chain in `vinculo_sbt`. The scoring engine in `api/calculate-score.js` computes a score from Horizon transaction history and maps it to a tier number. `api/evaluate-and-mint.js` is the only path that writes a new tier to the contract.
+
+---
+
+## Where to make common changes
+
+| Change | Files to touch |
+|---|---|
+| Add a new page | `src/pages/`, `src/App.tsx` (add route) |
+| Change credit limits | `api/get-available-credit.js` → `CREDIT_LIMITS` |
+| Change score thresholds | `api/calculate-score.js` → tier mapping block |
+| Change staking APY | `src/context/AppContext.tsx` → `STAKING_APY` |
+| Add a contract function call | `src/stellar/queries.ts` (read) or component (write, Freighter-signed) |
+| Change Supabase schema | `supabase/migrations/` (new migration file) |
+| Add an API endpoint | `api/<name>.js` + entry in `vercel.json` routes |

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -1,0 +1,130 @@
+# Core Flows
+
+## 1. Authentication and wallet setup
+
+```
+User visits app
+  └─ RequireWallet: no vinculo_wallet in localStorage?
+       └─ Redirect to /login
+
+/login
+  └─ Supabase email/password sign-in
+       └─ on success: supabase trigger creates profiles row
+            └─ WalletGate checks profiles.wallet_address
+                 └─ missing? → WalletSetupModal opens
+                      └─ User connects Freighter
+                           └─ wallet address saved to:
+                                - Supabase profiles.wallet_address
+                                - localStorage: vinculo_wallet
+                      └─ onboarded? check localStorage.vinculo_onboarded
+                           └─ no → redirect to /bienvenida (Onboarding)
+                           └─ yes → redirect to /
+```
+
+---
+
+## 2. Deposit
+
+```
+User taps "Depositar Ganancias" on Index
+  └─ DepositModal opens
+       └─ User enters XLM amount
+            └─ requestAccess() → Freighter returns address
+                 └─ Build TransactionBuilder with staking_pool.deposit(address, amount)
+                      └─ server.prepareTransaction(tx)
+                           └─ signTransaction(xdr) via Freighter
+                                └─ server.sendTransaction(signedTx)
+                                     └─ AppContext.addDeposit(amount)
+                                          └─ ProgressRing and BalanceCard re-render
+```
+
+**Key files:** `src/components/DepositModal.tsx`, `src/stellar/contracts.ts`
+
+---
+
+## 3. Credit scoring and NFT minting
+
+```
+User opens /perfil and taps "Reclamar NFT"
+  └─ POST /api/evaluate-and-mint
+       { userAddress, totalVolume }
+         └─ internally: POST /api/calculate-score
+              { address, totalDeposited }
+                └─ fetch Horizon /accounts/{address}/effects (last 120)
+                     └─ filter: account_credited (deposit) / account_debited (withdrawal)
+                          └─ computeFinancialReputation(history, totalDeposited)
+                               └─ weightedVolume × retentionRate × activityFactor / 60
+                                    └─ map score → tier (0–4)
+         └─ tier >= 1?
+              └─ yes: admin keypair signs vinculo_sbt.mint(admin, userAddress, tier)
+                        └─ returns { txHash, tier, tierName, status: "minted" }
+              └─ no:  returns { status: "pending", tier: 0 }
+```
+
+**Score formula:**
+```
+score = (weightedVolume × retentionRate × log10(txCount + 1)) / 60
+
+weightedVolume = Σ deposit.amount × (1 / (daysAgo + 1))
+retentionRate  = currentBalance / totalDeposited
+```
+
+If `currentBalance < 10% of totalDeposited`, score is penalized by 80%.
+
+**Key files:** `api/evaluate-and-mint.js`, `api/calculate-score.js`
+
+---
+
+## 4. Available credit display
+
+```
+CreditSection mounts (and every 8 seconds)
+  └─ POST /api/get-available-credit { userAddress }
+       └─ admin keypair simulates vinculo_sbt.get_tier(userAddress)
+            └─ returns tier number (0–4)
+                 └─ look up CREDIT_LIMITS[tier]
+                      └─ return { tier, tierName, availableCredit, currency: "XLM" }
+  └─ tier >= 1 → show credit limit and "Retirar" button
+  └─ tier == 0 → show locked state
+```
+
+**Key files:** `api/get-available-credit.js`, `src/components/CreditSection.tsx`
+
+---
+
+## 5. Loan request and repayment
+
+```
+User taps "Retirar a mi Wallet" in CreditSection
+  └─ requestAccess() → Freighter address
+       └─ validate address === localStorage.vinculo_wallet
+            └─ Build vinculo_lending.request_loan(address, amountInStroops, months=1)
+                 └─ server.prepareTransaction → signTransaction → sendTransaction
+                      └─ AppContext.withdrawCredit()
+                           └─ 60-second repayment countdown starts
+
+User taps "Pagar X XLM"
+  └─ Build vinculo_lending.repay(address, principal × 1.05 in stroops)
+       └─ server.prepareTransaction → signTransaction → sendTransaction
+            └─ window.location.reload()
+```
+
+**Interest rate:** 5% flat, applied at repayment time in the UI.  
+**Key files:** `src/components/CreditSection.tsx`
+
+---
+
+## 6. Staking balance read
+
+```
+BalanceCard / Perfil mount
+  └─ fetchContractBalance(walletAddress)   [src/stellar/queries.ts]
+       └─ simulate staking_pool.get_balance(address)
+            └─ scValToNative(retval) / 10_000_000  → XLM balance
+
+  └─ fetchStakeInfo(walletAddress)         [src/stellar/queries.ts]
+       └─ simulate staking_pool.get_stake(address)
+            └─ returns [amount, unlockTime, months, apy]
+```
+
+Both calls are read-only simulations (no transaction submitted, no fee charged).


### PR DESCRIPTION
## What

Adds architecture and flow documentation so contributors can navigate the codebase without needing a walkthrough.

## Why

There was no written record of how the layers connect, which files own which responsibilities, or how data moves through the system. This made onboarding slow and error-prone.

## Changes

**docs/architecture.md** (new)
- Four-layer diagram: React frontend → Vercel API → Supabase → Soroban contracts
- Routing table with auth guards explained
- Component responsibilities at a glance
- Full map of which contract functions are called from where
- Tier system table (score thresholds → credit limits)
- "Where to make common changes" quick-reference for the most frequent contributor tasks

**docs/flows.md** (new)
Step-by-step walkthroughs for every cross-layer operation:
1. Auth + wallet setup (Supabase → Freighter → localStorage)
2. Deposit (DepositModal → Freighter → staking_pool contract)
3. Credit scoring + NFT minting (Perfil → evaluate-and-mint → calculate-score → vinculo_sbt.mint)
4. Available credit display (CreditSection → get-available-credit → vinculo_sbt.get_tier)
5. Loan request + repayment (CreditSection → vinculo_lending)
6. Staking balance read (queries.ts → staking_pool simulation)

**README.md** (updated)
- Added Architecture section with links to both docs files

Closes #21