### PR TITLE
feat: add reproducible migration/upgrade scripts for Soroban contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Vyn has four layers: a React frontend, Vercel serverless API functions, Supabase
 
 - [Architecture overview](docs/architecture.md) — layers, components, contracts, and where to make common changes.
 - [Core flows](docs/flows.md) — step-by-step walkthroughs of auth, deposit, scoring/minting, credit, and loan flows.
+- [Contract migration & upgrade guide](docs/contracts/migration.md) — reproducible deploy, upgrade, and rollback steps for all three Soroban contracts.
 
 ## Notes For Collaborators
 

--- a/docs/contracts/migration.md
+++ b/docs/contracts/migration.md
@@ -1,0 +1,281 @@
+# Contract Migration & Upgrade Guide
+
+Covers the full deploy and upgrade sequence for the three Soroban contracts in this repo.  
+All commands target **Stellar Testnet** (`--network testnet`). Swap `testnet` for `futurenet` or a local node as needed.
+
+## Prerequisites
+
+```bash
+# Rust + wasm target
+rustup target add wasm32-unknown-unknown
+
+# Stellar CLI (must be ≥ 21.x to match soroban-sdk 21.7.6)
+cargo install --locked stellar-cli --features opt
+
+# Confirm versions
+stellar --version
+rustc --version
+```
+
+Set these shell variables once per session (or export them from `.env.local`):
+
+```bash
+export ADMIN_SECRET="S..."          # Secret key of the deployer/admin account
+export ADMIN_PUBLIC="G..."          # Matching public key
+export NETWORK="testnet"
+export RPC_URL="https://soroban-testnet.stellar.org"
+export NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+```
+
+Fund the account on testnet if needed:
+
+```bash
+stellar keys fund $ADMIN_PUBLIC --network $NETWORK
+```
+
+---
+
+## Deploy Order
+
+`vinculo_lending` depends on `vinculo_sbt` at the Rust crate level, so deploy in this order:
+
+1. `vinculo_sbt`
+2. `staking_pool` (independent, can be parallel with step 1)
+3. `vinculo_lending`
+
+---
+
+## 1. vinculo_sbt
+
+### Build
+
+```bash
+cd backend/contracts/vinculo_sbt
+cargo build --release --target wasm32-unknown-unknown
+```
+
+Wasm output: `target/wasm32-unknown-unknown/release/vinculo_sbt.wasm`
+
+### Deploy (first time)
+
+```bash
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/vinculo_sbt.wasm \
+  --source $ADMIN_SECRET \
+  --network $NETWORK
+```
+
+Save the printed contract ID:
+
+```bash
+export SBT_CONTRACT_ID="C..."
+```
+
+### Initialize
+
+```bash
+stellar contract invoke \
+  --id $SBT_CONTRACT_ID \
+  --source $ADMIN_SECRET \
+  --network $NETWORK \
+  -- init \
+  --admin $ADMIN_PUBLIC
+```
+
+`init` panics if called twice — it is safe to re-run only on a freshly deployed contract.
+
+### Upgrade (existing deployment)
+
+```bash
+# 1. Build the new wasm
+cargo build --release --target wasm32-unknown-unknown
+
+# 2. Upload the new wasm blob and capture the hash
+WASM_HASH=$(stellar contract upload \
+  --wasm target/wasm32-unknown-unknown/release/vinculo_sbt.wasm \
+  --source $ADMIN_SECRET \
+  --network $NETWORK)
+
+# 3. Upgrade the live contract in-place
+stellar contract invoke \
+  --id $SBT_CONTRACT_ID \
+  --source $ADMIN_SECRET \
+  --network $NETWORK \
+  -- upgrade \
+  --new_wasm_hash $WASM_HASH
+```
+
+> **Note:** `upgrade` is a built-in Soroban host function. The contract code is replaced but all storage (tiers, admin) is preserved.
+
+---
+
+## 2. staking_pool
+
+### Build
+
+```bash
+cd backend/contracts/staking_pool
+cargo build --release --target wasm32-unknown-unknown
+```
+
+Wasm output: `target/wasm32-unknown-unknown/release/staking_pool.wasm`
+
+### Deploy (first time)
+
+```bash
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/staking_pool.wasm \
+  --source $ADMIN_SECRET \
+  --network $NETWORK
+```
+
+```bash
+export STAKING_CONTRACT_ID="C..."
+```
+
+### Initialize
+
+Requires a Stellar Asset Contract (SAC) address for the token. Use the XLM SAC on testnet or deploy your own:
+
+```bash
+stellar contract invoke \
+  --id $STAKING_CONTRACT_ID \
+  --source $ADMIN_SECRET \
+  --network $NETWORK \
+  -- init \
+  --token <TOKEN_SAC_ADDRESS>
+```
+
+### Upgrade
+
+```bash
+cd backend/contracts/staking_pool
+cargo build --release --target wasm32-unknown-unknown
+
+WASM_HASH=$(stellar contract upload \
+  --wasm target/wasm32-unknown-unknown/release/staking_pool.wasm \
+  --source $ADMIN_SECRET \
+  --network $NETWORK)
+
+stellar contract invoke \
+  --id $STAKING_CONTRACT_ID \
+  --source $ADMIN_SECRET \
+  --network $NETWORK \
+  -- upgrade \
+  --new_wasm_hash $WASM_HASH
+```
+
+> All balances and stake records in persistent storage survive the upgrade.
+
+---
+
+## 3. vinculo_lending
+
+Depends on `vinculo_sbt` — `$SBT_CONTRACT_ID` must be set before deploying.
+
+### Build
+
+```bash
+cd backend/contracts/vinculo_lending
+cargo build --release --target wasm32-unknown-unknown
+```
+
+Wasm output: `target/wasm32-unknown-unknown/release/vinculo_lending.wasm`
+
+### Deploy (first time)
+
+```bash
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/vinculo_lending.wasm \
+  --source $ADMIN_SECRET \
+  --network $NETWORK
+```
+
+```bash
+export LENDING_CONTRACT_ID="C..."
+```
+
+### Initialize
+
+```bash
+stellar contract invoke \
+  --id $LENDING_CONTRACT_ID \
+  --source $ADMIN_SECRET \
+  --network $NETWORK \
+  -- init_lending \
+  --token <TOKEN_SAC_ADDRESS> \
+  --sbt $SBT_CONTRACT_ID
+```
+
+### Fund the pool
+
+```bash
+stellar contract invoke \
+  --id $LENDING_CONTRACT_ID \
+  --source $ADMIN_SECRET \
+  --network $NETWORK \
+  -- fund_pool \
+  --from $ADMIN_PUBLIC \
+  --amount 10000000000
+```
+
+### Upgrade
+
+```bash
+cd backend/contracts/vinculo_lending
+cargo build --release --target wasm32-unknown-unknown
+
+WASM_HASH=$(stellar contract upload \
+  --wasm target/wasm32-unknown-unknown/release/vinculo_lending.wasm \
+  --source $ADMIN_SECRET \
+  --network $NETWORK)
+
+stellar contract invoke \
+  --id $LENDING_CONTRACT_ID \
+  --source $ADMIN_SECRET \
+  --network $NETWORK \
+  -- upgrade \
+  --new_wasm_hash $WASM_HASH
+```
+
+> Active loans (`Loan` entries in persistent storage) are preserved across upgrades.
+
+---
+
+## After Any Deploy or Upgrade
+
+Update `.env.local` with the new contract IDs:
+
+```
+NFT_CONTRACT_ID=<new SBT_CONTRACT_ID>
+VITE_LENDING_CONTRACT_ID=<new LENDING_CONTRACT_ID>
+```
+
+Restart the backend and frontend so they pick up the new values.
+
+---
+
+## Rollback / Recovery
+
+Soroban does not support reverting a `upgrade` call directly. Recovery options:
+
+| Scenario | Action |
+|---|---|
+| Bad upgrade (logic bug) | Re-upload the previous wasm blob and call `upgrade` again with the old hash. Keep the old `.wasm` file or its hash in version control. |
+| Bad deploy (wrong init args) | Deploy a fresh contract instance, re-initialize with correct args, update `.env.local`. |
+| Corrupted storage | There is no on-chain rollback. Redeploy and migrate user state off-chain if needed. |
+| Lost contract ID | Query `stellar contract id` or check the deployment transaction in the Stellar explorer. |
+
+**Best practice:** before any upgrade, record the current wasm hash:
+
+```bash
+stellar contract info --id $CONTRACT_ID --network $NETWORK
+```
+
+Store that hash so you can roll back by re-uploading the old wasm.
+
+---
+
+## Automated Script
+
+See [`scripts/deploy_contracts.sh`](../../scripts/deploy_contracts.sh) for a single script that runs the full deploy + init sequence from a clean clone.

--- a/scripts/deploy_contracts.sh
+++ b/scripts/deploy_contracts.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# deploy_contracts.sh — full deploy + init sequence for all three Soroban contracts.
+# Run from the repo root after setting the required environment variables.
+#
+# Required env vars:
+#   ADMIN_SECRET   — deployer secret key (S...)
+#   ADMIN_PUBLIC   — matching public key  (G...)
+#   TOKEN_ADDRESS  — SAC address of the token used by staking_pool and vinculo_lending
+#
+# Optional:
+#   NETWORK        — defaults to "testnet"
+#
+# Usage:
+#   export ADMIN_SECRET="S..."
+#   export ADMIN_PUBLIC="G..."
+#   export TOKEN_ADDRESS="C..."
+#   bash scripts/deploy_contracts.sh
+
+set -euo pipefail
+
+NETWORK="${NETWORK:-testnet}"
+CONTRACTS_DIR="backend/contracts"
+
+# ── Validate required vars ────────────────────────────────────────────────────
+: "${ADMIN_SECRET:?Set ADMIN_SECRET before running this script}"
+: "${ADMIN_PUBLIC:?Set ADMIN_PUBLIC before running this script}"
+: "${TOKEN_ADDRESS:?Set TOKEN_ADDRESS before running this script}"
+
+echo "==> Network: $NETWORK"
+echo "==> Admin:   $ADMIN_PUBLIC"
+
+# ── Helper: build + deploy + return contract ID ───────────────────────────────
+deploy_contract() {
+  local name="$1"
+  local dir="$CONTRACTS_DIR/$name"
+
+  echo ""
+  echo "── Building $name ──"
+  (cd "$dir" && cargo build --release --target wasm32-unknown-unknown --quiet)
+
+  local wasm="$dir/target/wasm32-unknown-unknown/release/${name}.wasm"
+  echo "── Deploying $name ──"
+  stellar contract deploy \
+    --wasm "$wasm" \
+    --source "$ADMIN_SECRET" \
+    --network "$NETWORK"
+}
+
+# ── Helper: upload wasm and return hash ───────────────────────────────────────
+upload_wasm() {
+  local name="$1"
+  local dir="$CONTRACTS_DIR/$name"
+  local wasm="$dir/target/wasm32-unknown-unknown/release/${name}.wasm"
+
+  stellar contract upload \
+    --wasm "$wasm" \
+    --source "$ADMIN_SECRET" \
+    --network "$NETWORK"
+}
+
+# ── 1. vinculo_sbt ────────────────────────────────────────────────────────────
+SBT_CONTRACT_ID=$(deploy_contract "vinculo_sbt")
+echo "SBT_CONTRACT_ID=$SBT_CONTRACT_ID"
+
+stellar contract invoke \
+  --id "$SBT_CONTRACT_ID" \
+  --source "$ADMIN_SECRET" \
+  --network "$NETWORK" \
+  -- init \
+  --admin "$ADMIN_PUBLIC"
+echo "==> vinculo_sbt initialized"
+
+# ── 2. staking_pool ───────────────────────────────────────────────────────────
+STAKING_CONTRACT_ID=$(deploy_contract "staking_pool")
+echo "STAKING_CONTRACT_ID=$STAKING_CONTRACT_ID"
+
+stellar contract invoke \
+  --id "$STAKING_CONTRACT_ID" \
+  --source "$ADMIN_SECRET" \
+  --network "$NETWORK" \
+  -- init \
+  --token "$TOKEN_ADDRESS"
+echo "==> staking_pool initialized"
+
+# ── 3. vinculo_lending ────────────────────────────────────────────────────────
+LENDING_CONTRACT_ID=$(deploy_contract "vinculo_lending")
+echo "LENDING_CONTRACT_ID=$LENDING_CONTRACT_ID"
+
+stellar contract invoke \
+  --id "$LENDING_CONTRACT_ID" \
+  --source "$ADMIN_SECRET" \
+  --network "$NETWORK" \
+  -- init_lending \
+  --token "$TOKEN_ADDRESS" \
+  --sbt "$SBT_CONTRACT_ID"
+echo "==> vinculo_lending initialized"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "════════════════════════════════════════"
+echo " Deployment complete. Add to .env.local:"
+echo "════════════════════════════════════════"
+echo "NFT_CONTRACT_ID=$SBT_CONTRACT_ID"
+echo "VITE_LENDING_CONTRACT_ID=$LENDING_CONTRACT_ID"
+echo "# STAKING_CONTRACT_ID=$STAKING_CONTRACT_ID"
+echo "════════════════════════════════════════"

--- a/scripts/upgrade_contract.sh
+++ b/scripts/upgrade_contract.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# upgrade_contract.sh — rebuild and upgrade a single deployed Soroban contract in-place.
+# Preserves all on-chain storage (tiers, balances, loans).
+#
+# Required env vars:
+#   ADMIN_SECRET      — deployer secret key (S...)
+#   CONTRACT_ID       — ID of the contract to upgrade (C...)
+#   CONTRACT_NAME     — one of: vinculo_sbt | staking_pool | vinculo_lending
+#
+# Optional:
+#   NETWORK           — defaults to "testnet"
+#
+# Usage:
+#   export ADMIN_SECRET="S..."
+#   export CONTRACT_ID="C..."
+#   export CONTRACT_NAME="vinculo_sbt"
+#   bash scripts/upgrade_contract.sh
+
+set -euo pipefail
+
+NETWORK="${NETWORK:-testnet}"
+CONTRACTS_DIR="backend/contracts"
+
+: "${ADMIN_SECRET:?Set ADMIN_SECRET}"
+: "${CONTRACT_ID:?Set CONTRACT_ID}"
+: "${CONTRACT_NAME:?Set CONTRACT_NAME (vinculo_sbt | staking_pool | vinculo_lending)}"
+
+DIR="$CONTRACTS_DIR/$CONTRACT_NAME"
+WASM="$DIR/target/wasm32-unknown-unknown/release/${CONTRACT_NAME}.wasm"
+
+echo "==> Upgrading $CONTRACT_NAME ($CONTRACT_ID) on $NETWORK"
+
+# 1. Record current wasm hash for rollback reference
+echo "── Current wasm hash (save for rollback) ──"
+stellar contract info --id "$CONTRACT_ID" --network "$NETWORK" 2>/dev/null || true
+
+# 2. Build
+echo "── Building $CONTRACT_NAME ──"
+(cd "$DIR" && cargo build --release --target wasm32-unknown-unknown --quiet)
+
+# 3. Upload new wasm
+echo "── Uploading wasm ──"
+WASM_HASH=$(stellar contract upload \
+  --wasm "$WASM" \
+  --source "$ADMIN_SECRET" \
+  --network "$NETWORK")
+echo "New wasm hash: $WASM_HASH"
+
+# 4. Upgrade
+echo "── Upgrading contract ──"
+stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --source "$ADMIN_SECRET" \
+  --network "$NETWORK" \
+  -- upgrade \
+  --new_wasm_hash "$WASM_HASH"
+
+echo "==> $CONTRACT_NAME upgraded successfully"
+echo ""
+echo "To roll back, re-upload the previous wasm and run:"
+echo "  stellar contract invoke --id $CONTRACT_ID --source \$ADMIN_SECRET --network $NETWORK -- upgrade --new_wasm_hash <OLD_HASH>"


### PR DESCRIPTION


Contracts: vinculo_sbt, staking_pool, vinculo_lending (testnet)

Changes:
- docs/contracts/migration.md: full deploy, upgrade, and rollback guide for all three contracts with exact stellar-cli command sequences
- scripts/deploy_contracts.sh: automated full deploy + init from clean clone
- scripts/upgrade_contract.sh: single-contract in-place upgrade with rollback instructions

Manual step for reviewer: set ADMIN_SECRET, ADMIN_PUBLIC, TOKEN_ADDRESS
then run: bash scripts/deploy_contracts.sh
Closes #40