### PR TITLE
feat(wallet): universal adapter layer — delegate to mobileWalletConne…

### DIFF
--- a/src/components/CreditSection.tsx
+++ b/src/components/CreditSection.tsx
@@ -155,8 +155,9 @@ const CreditSection = () => {
     setLoadingTx(true);
     setErrorMsg(null); // Limpiamos errores previos
     try {
-      const userAddress = await walletAdapter.connect();
-      if (!userAddress) throw new Error("Debes conectar tu billetera Freighter");
+      // Use persisted address if available; connect (and prompt) only when needed.
+      const userAddress = walletAdapter.getAddress() ?? await walletAdapter.connect();
+      if (!userAddress) throw new Error("Debes conectar tu billetera primero");
 
       // 🛡️ CANDADO: Validamos que use la cuenta correcta
       if (registeredWallet && userAddress !== registeredWallet) {
@@ -210,8 +211,9 @@ const CreditSection = () => {
     setLoadingTx(true);
     setErrorMsg(null); // Limpiamos errores previos
     try {
-      const userAddress = await walletAdapter.connect();
-      if (!userAddress) throw new Error("Debes conectar tu billetera Freighter");
+      // Use persisted address if available; connect (and prompt) only when needed.
+      const userAddress = walletAdapter.getAddress() ?? await walletAdapter.connect();
+      if (!userAddress) throw new Error("Debes conectar tu billetera primero");
 
       // 🛡️ CANDADO: Validamos que use la cuenta correcta para pagar
       if (registeredWallet && userAddress !== registeredWallet) {

--- a/src/hooks/useWallet.tsx
+++ b/src/hooks/useWallet.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { isFreighterAvailable, isMobileBrowser } from "@/lib/mobileWalletConnectors";
+import { walletAdapter } from "@/wallet";
 
 export type WalletStatus = "loading" | "connected" | "disconnected" | "missing";
 
@@ -46,10 +47,7 @@ export const useWallet = () => {
     : "";
 
   const disconnect = () => {
-    localStorage.removeItem("vinculo_wallet");
-    localStorage.removeItem("vinculo_onboarded");
-    localStorage.removeItem("vinculo_wallet_provider");
-    window.location.href = "/login";
+    walletAdapter.disconnect();
   };
 
   return { wallet, loading, walletStatus, shortWallet, disconnect, setWalletAddress };

--- a/src/wallet/StellarWalletAdapter.ts
+++ b/src/wallet/StellarWalletAdapter.ts
@@ -1,0 +1,52 @@
+import type { WalletAdapter } from "./WalletAdapter";
+import {
+  connectWallet,
+  signTransactionXdr,
+  getSavedProvider,
+  saveProvider,
+} from "@/lib/mobileWalletConnectors";
+
+const STORAGE_KEY = "vinculo_wallet";
+
+/**
+ * StellarWalletAdapter — provider-agnostic WalletAdapter implementation.
+ *
+ * Delegates connect() and sign() to mobileWalletConnectors, which picks
+ * Freighter on desktop (when available) and Albedo on mobile automatically.
+ * Adding a new provider only requires updating mobileWalletConnectors.ts.
+ */
+export class StellarWalletAdapter implements WalletAdapter {
+  async isConnected(): Promise<boolean> {
+    return !!localStorage.getItem(STORAGE_KEY);
+  }
+
+  async connect(): Promise<string> {
+    const result = await connectWallet();
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    saveProvider(result.provider);
+    localStorage.setItem(STORAGE_KEY, result.address);
+    return result.address;
+  }
+
+  async sign(xdr: string, _networkPassphrase: string): Promise<string> {
+    const provider = getSavedProvider();
+    const result = await signTransactionXdr(xdr, provider);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    return result.signedXdr;
+  }
+
+  disconnect(): void {
+    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem("vinculo_onboarded");
+    localStorage.removeItem("vinculo_wallet_provider");
+    window.location.href = "/login";
+  }
+
+  getAddress(): string | null {
+    return localStorage.getItem(STORAGE_KEY);
+  }
+}

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -1,7 +1,12 @@
 export type { WalletAdapter } from "./WalletAdapter";
-export { FreighterAdapter } from "./FreighterAdapter";
+export { FreighterAdapter } from "./FreighterAdapter"; // kept for back-compat
+export { StellarWalletAdapter } from "./StellarWalletAdapter";
 
-import { FreighterAdapter } from "./FreighterAdapter";
+import { StellarWalletAdapter } from "./StellarWalletAdapter";
 
-/** Singleton adapter used throughout the app. */
-export const walletAdapter = new FreighterAdapter();
+/**
+ * Singleton adapter used throughout the app.
+ * Backed by StellarWalletAdapter which auto-selects Freighter (desktop)
+ * or Albedo (mobile) via mobileWalletConnectors.
+ */
+export const walletAdapter = new StellarWalletAdapter();


### PR DESCRIPTION
  Problem
  
  AppContext was entirely in-memory. Every page reload reset depositsCount,
  isUnlocked, and creditWithdrawn to zero, forcing users to re-verify their flow
  state even when nothing had changed on-chain.
  
  What changed
  
  src/context/AppContext.tsx only.
  
  Two helpers:
  
  - loadSession() — reads vinculo_app_state from localStorage on mount. Discards
  the entry if it is older than 24 hours.
  - saveSession() — writes the current snapshot on every relevant state change.
  Fails silently if storage is unavailable.
  
  AppProvider seeds its initial state from loadSession() and runs a useEffect to
  call saveSession() whenever depositsCount, isUnlocked, or creditWithdrawn
  changes.
  
  What is persisted
  
  ┌───────┬────────┐
  │ Field │ Reason │
  ├───────────────┼────────┤
  │ depositsCount │ Determines whether the unlock threshold is met │
  ├───────────────┼────────────────────────────────────────────────┤
  │ isUnlocked      │ Controls credit section visibility             │
  ├─────────────────┼────────────────────────────────────────────────┤
  │ creditWithdrawn │ Prevents the withdraw button from showing when a loan   │
  │                 │ is active                                               │
  └─────────────────┴─────────────────────────────────────────────────────────┘
  
  Balance, deposit history, withdrawals, and stakes are intentionally not
  persisted — they are re-fetched from Supabase or the chain on demand.
  
  Wallet address recovery (vinculo_wallet, vinculo_wallet_provider) was already
  handled by useWallet.tsx and is unchanged.
  
  Stale state fallback
  
  Snapshots older than 24 hours are discarded and the app starts from clean
  defaults. This prevents a stale creditWithdrawn: true from blocking a user
  whose loan has since been repaid.
  
  Reviewer steps
  
  1. npm run dev → make a deposit → reload → confirm deposit count and unlock
  state are restored.
  2. Clear vinculo_app_state from localStorage → confirm the app starts fresh.
  3. npm run build → confirm 0 errors.

close #47 