### PR TITLE
feat: improve wallet connection UX with clear error guidance and retr…

### DIFF
--- a/src/components/WalletSetupModal.tsx
+++ b/src/components/WalletSetupModal.tsx
@@ -9,6 +9,21 @@ interface WalletSetupModalProps {
   onComplete: () => void;
 }
 
+function friendlyError(
+  raw: string,
+  cancelled: boolean,
+  t: (key: string) => string
+): string {
+  if (cancelled) return t("wallet_setup.error_cancelled");
+  const lower = raw.toLowerCase();
+  if (lower.includes("popup")) return t("wallet_setup.error_popup_blocked");
+  if (lower.includes("locked") || lower.includes("bloqueada"))
+    return t("wallet_setup.error_wallet_locked");
+  if (lower.includes("network") || lower.includes("fetch"))
+    return t("wallet_setup.error_no_network");
+  return t("wallet_setup.error_generic");
+}
+
 const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
   const { user } = useAuth();
   const { isMobile, isFreighterReady, connect } = useMobileWallet();
@@ -28,11 +43,7 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
     const result = await connect();
 
     if (!result.ok) {
-      setError(
-        result.cancelled
-          ? t("wallet_setup.error_cancelled")
-          : result.error
-      );
+      setError(friendlyError(result.error, result.cancelled, t));
       setConnecting(false);
       return;
     }
@@ -137,7 +148,7 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
                   className="flex items-center justify-center gap-1 text-xs text-primary hover:underline py-1"
                 >
                   <ExternalLink className="w-3 h-3" />
-                  Instalar Freighter en su lugar
+                  {t("wallet_setup.install_freighter_alt")}
                 </a>
               </div>
             ) : (
@@ -163,7 +174,7 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
             )}
 
             {error && (
-              <div className="space-y-2">
+              <div className="space-y-3">
                 <div className="flex items-start gap-2 bg-destructive/10 rounded-lg px-3 py-2.5">
                   <AlertCircle className="w-4 h-4 text-destructive flex-shrink-0 mt-0.5" />
                   <p className="text-xs text-destructive">{error}</p>
@@ -171,8 +182,9 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
                 <button
                   onClick={() => { setError(null); handleConnect(); }}
                   disabled={connecting}
-                  className="w-full text-xs font-semibold text-primary hover:underline py-1 disabled:opacity-50"
+                  className="w-full flex items-center justify-center gap-2 rounded-xl bg-primary text-primary-foreground px-4 py-2.5 text-sm font-bold shadow-sm hover:bg-primary/90 transition-all disabled:opacity-60"
                 >
+                  {connecting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Wallet className="w-4 h-4" />}
                   {t("common.retry")}
                 </button>
               </div>
@@ -204,7 +216,7 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
                 className="flex items-center justify-center gap-1 text-xs text-primary hover:underline"
               >
                 <ExternalLink className="w-3 h-3" />
-                ¿No tienes Freighter? Descárgala aquí
+                {t("wallet_setup.install_freighter_link")}
               </a>
             )}
           </>

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -100,7 +100,7 @@ const es = {
     deposit_button: "Depositar Ganancias",
     wallet_disconnected_title: "Wallet desconectada",
     wallet_disconnected_description:
-      "Freighter no está disponible. Reconecta tu wallet para operar.",
+      "Tu wallet no está disponible. Verifica que Freighter esté instalado y desbloqueado, o usa el botón de reconexión.",
     reconnect: "Reconectar",
     loading_wallet: "Cargando...",
   },
@@ -173,8 +173,18 @@ const es = {
     connect_freighter: "Conectar con Freighter",
     freighter_not_detected: "Freighter no detectado",
     freighter_not_detected_description:
-      "Instala la extensión o continúa con Albedo...",
-    error_cancelled: "Conexión cancelada. Puedes intentarlo de nuevo.",
+      "Instala la extensión o continúa con Albedo, una wallet web que no requiere instalación.",
+    install_freighter_alt: "Instalar Freighter en su lugar",
+    install_freighter_link: "¿No tienes Freighter? Descárgala aquí",
+    error_cancelled: "Conexión cancelada. Puedes intentarlo de nuevo cuando quieras.",
+    error_popup_blocked:
+      "El popup fue bloqueado. Permite ventanas emergentes para este sitio e intenta de nuevo.",
+    error_wallet_locked:
+      "Tu wallet está bloqueada. Desbloquéala e intenta de nuevo.",
+    error_no_network:
+      "Sin conexión a la red. Verifica tu internet e intenta de nuevo.",
+    error_generic:
+      "Error de conexión. Verifica que tu wallet esté desbloqueada e intenta de nuevo.",
     error_save: "No se pudo guardar. Intenta de nuevo.",
   },
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -54,7 +54,7 @@ const Index = () => {
             </p>
           </div>
           <button
-            onClick={disconnect}
+            onClick={() => window.location.reload()}
             className="text-[11px] font-bold text-amber-700 hover:underline flex-shrink-0"
           >
             {t("home.reconnect")}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -135,12 +135,19 @@ const Login = () => {
 
         {/* ── Error notification ─────────────────────────────────────────── */}
         {error && (
-          <div
-            key={error}
-            className="p-3 rounded-xl bg-destructive/10 border border-destructive/20 text-destructive text-[11px] font-bold uppercase text-center animate-shake mt-4"
-          >
-            <AlertCircle className="w-4 h-4 inline mr-2 mb-0.5" />
-            {error}
+          <div className="space-y-3 mt-4">
+            <div className="p-3 rounded-xl bg-destructive/10 border border-destructive/20 text-destructive text-[11px] font-bold uppercase text-center animate-shake">
+              <AlertCircle className="w-4 h-4 inline mr-2 mb-0.5" />
+              {error}
+            </div>
+            <button
+              onClick={connectWallet}
+              disabled={loading}
+              className="w-full flex items-center justify-center gap-2 rounded-2xl bg-primary text-primary-foreground px-5 py-3 text-sm font-bold shadow-lg shadow-primary/20 active:scale-[0.98] transition-all disabled:opacity-60"
+            >
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Wallet className="h-4 w-4" />}
+              {t("common.retry")}
+            </button>
           </div>
         )}
       </div>


### PR DESCRIPTION


Closes #48 

- Add prominent retry buttons in Login and WalletSetupModal error states
- Add specific error messages for common wallet failures (popup blocked, locked, no network)
- Fix reconnect button in Index to trigger page reload instead of disconnect
- Improve copy to guide users on recovery actions