### PR TITLE
fix: add server-side validation for critical API endpoints

### DIFF
--- a/api/calculate-score.js
+++ b/api/calculate-score.js
@@ -1,3 +1,5 @@
+import { validateBody, calculateScoreBodySchema, reportValidationError } from "./validation.js";
+
 const HORIZON_URL = "https://horizon-testnet.stellar.org";
 // Para entornos de testnet reducimos el requisito para facilitar pruebas
 const MIN_TX_REQUIRED = 3;
@@ -115,8 +117,16 @@ export default async function handler(req, res) {
   if (req.method === 'OPTIONS') return res.status(200).end();
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
 
-  const { address, totalDeposited: clientTotalDeposited } = req.body;
-  if (!address) return res.status(400).json({ error: "Wallet requerida" });
+  let address;
+  let clientTotalDeposited;
+
+  try {
+    const validated = validateBody(calculateScoreBodySchema, req.body || {});
+    address = validated.address;
+    clientTotalDeposited = validated.totalDeposited;
+  } catch (error) {
+    return reportValidationError(res, error);
+  }
 
   try {
     const history = await getCleanHistory(address);

--- a/api/evaluate-and-mint.js
+++ b/api/evaluate-and-mint.js
@@ -9,6 +9,7 @@ import {
   Transaction
 } from "@stellar/stellar-sdk";
 import dotenv from "dotenv";
+import { validateBody, evaluateAndMintBodySchema, reportValidationError } from "./validation.js";
 
 dotenv.config();
 
@@ -101,10 +102,17 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const { userAddress, deposits, totalVolume } = req.body || {};
+  let userAddress;
+  let deposits;
+  let totalVolume;
 
-  if (!userAddress) {
-    return res.status(400).json({ error: 'userAddress es requerido', status: 'error' });
+  try {
+    const validated = validateBody(evaluateAndMintBodySchema, req.body || {});
+    userAddress = validated.userAddress;
+    deposits = validated.deposits;
+    totalVolume = validated.totalVolume;
+  } catch (error) {
+    return reportValidationError(res, error);
   }
 
   const fallbackVolumeFromDeposits = Array.isArray(deposits)

--- a/api/get-available-credit.js
+++ b/api/get-available-credit.js
@@ -1,4 +1,5 @@
 import { Keypair, rpc, TransactionBuilder, Networks, Operation, BASE_FEE, nativeToScVal, scValToNative } from "@stellar/stellar-sdk";
+import { validateBody, getAvailableCreditBodySchema, reportValidationError } from "./validation.js";
 
 const CREDIT_LIMITS = {
   0: { name: "Bronce", amount: 0 },
@@ -19,8 +20,14 @@ export default async function handler(req, res) {
   if (req.method === 'OPTIONS') return res.status(200).end();
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
   
-  const { userAddress } = req.body;
-  if (!userAddress) return res.status(400).json({ error: "Falta wallet" });
+  let userAddress;
+
+  try {
+    const validated = validateBody(getAvailableCreditBodySchema, req.body || {});
+    userAddress = validated.userAddress;
+  } catch (error) {
+    return reportValidationError(res, error);
+  }
 
   try {
     const server = new rpc.Server(RPC_URL);

--- a/api/get-user-data.js
+++ b/api/get-user-data.js
@@ -1,4 +1,5 @@
 import { rpc, TransactionBuilder, Networks, Operation, BASE_FEE, nativeToScVal, scValToNative } from "@stellar/stellar-sdk";
+import { validateQuery, getUserDataQuerySchema, reportValidationError } from "./validation.js";
 
 const CONTRACT_ID = "CAIYBGMKSA5V5EYUFKGD5OCWWS5M34YC7MKUKE3BOQE2WZP3R7A4S2D2";
 const RPC_URL = "https://soroban-testnet.stellar.org";
@@ -9,10 +10,12 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const { address } = req.query;
-
-  if (!address) {
-    return res.status(400).json({ error: 'Falta la dirección de la wallet' });
+  let address;
+  try {
+    const validated = validateQuery(getUserDataQuerySchema, req.query || {});
+    address = validated.address;
+  } catch (error) {
+    return reportValidationError(res, error);
   }
 
   try {

--- a/api/validation.js
+++ b/api/validation.js
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+export class ValidationError extends Error {
+  constructor(error) {
+    super(ValidationError.formatErrorMessage(error));
+    this.name = "ValidationError";
+  }
+
+  static formatErrorMessage(error) {
+    const issues = error.issues.map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "request body";
+      return `${path}: ${issue.message}`;
+    });
+    return issues.join("; ");
+  }
+}
+
+const nonEmptyString = z.string().trim().min(1, { message: "es requerido" });
+const nonNegativeNumber = z.preprocess((value) => {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return Number(value);
+  }
+  return value;
+}, z.number({ invalid_type_error: "debe ser un número" }).nonnegative({ message: "debe ser mayor o igual a 0" }));
+
+export const calculateScoreBodySchema = z.object({
+  address: nonEmptyString.describe("Wallet requerida"),
+  totalDeposited: nonNegativeNumber.optional(),
+});
+
+export const depositSchema = z.object({
+  amount: nonNegativeNumber,
+});
+
+export const evaluateAndMintBodySchema = z.object({
+  userAddress: nonEmptyString.describe("userAddress es requerido"),
+  totalVolume: nonNegativeNumber.optional(),
+  deposits: z.array(depositSchema).optional(),
+});
+
+export const getAvailableCreditBodySchema = z.object({
+  userAddress: nonEmptyString.describe("userAddress es requerido"),
+});
+
+export const getUserDataQuerySchema = z.object({
+  address: nonEmptyString.describe("address es requerido"),
+});
+
+export function validateBody(schema, data) {
+  const parsed = schema.safeParse(data);
+  if (!parsed.success) {
+    throw new ValidationError(parsed.error);
+  }
+  return parsed.data;
+}
+
+export function validateQuery(schema, query) {
+  const parsed = schema.safeParse(query);
+  if (!parsed.success) {
+    throw new ValidationError(parsed.error);
+  }
+  return parsed.data;
+}
+
+export function reportValidationError(res, error) {
+  if (error instanceof ValidationError) {
+    return res.status(400).json({ error: error.message, status: "error" });
+  }
+  return res.status(500).json({ error: error.message || "Internal server error", status: "error" });
+}


### PR DESCRIPTION
Closes #43

This PR adds explicit request validation for the serverless API endpoints in `api/calculate-score.js`, `api/evaluate-and-mint.js`, `api/get-available-credit.js`, and `api/get-user-data.js`.

Accepted request shapes:
- `POST /api/calculate-score` with `{ address: string, totalDeposited?: number }`
- `POST /api/evaluate-and-mint` with `{ userAddress: string, totalVolume?: number, deposits?: [{ amount: number }] }`
- `POST /api/get-available-credit` with `{ userAddress: string }`
- `GET /api/get-user-data?address=<string>`

Rejected invalid cases:
- missing required `address` or `userAddress`
- empty string values for required addresses
- non-numeric or negative values for optional volume fields
- invalid `deposits` array items for `evaluate-and-mint`

A shared helper was introduced at `api/validation.js` with Zod schemas and consistent 400 responses for bad requests.

Validation performed:
- `npm run build` succeeded after installing dependencies
- direct handler invocation tests showed malformed input returns 400 for each endpoint