### PR TITLE
feat(metrics): add latency, conversion, and tx failure hooks (#35)

### DIFF
--- a/api/calculate-score.js
+++ b/api/calculate-score.js
@@ -118,6 +118,7 @@ export default async function handler(req, res) {
   const { address, totalDeposited: clientTotalDeposited } = req.body;
   if (!address) return res.status(400).json({ error: "Wallet requerida" });
 
+  const t0 = Date.now();
   try {
     const history = await getCleanHistory(address);
 
@@ -138,9 +139,16 @@ export default async function handler(req, res) {
 
     // Clamp a 0 para evitar valores negativos que corrompan retentionRate
     const result = computeFinancialReputation(history, Math.max(0, Number(effectiveTotal) || 0));
-    
+
+    const latencyMs = Date.now() - t0;
+    // METRIC: calculate-score latency and conversion (tier >= 1 = eligible user)
+    console.log(`[metric] calculate-score latency=${latencyMs}ms tier=${result.tier} eligible=${result.tier >= 1}`);
+
     return res.status(200).json(result);
   } catch (error) {
+    const latencyMs = Date.now() - t0;
+    // METRIC: calculate-score failure
+    console.log(`[metric] calculate-score latency=${latencyMs}ms error="${error.message}"`);
     return res.status(500).json({ error: error.message });
   }
 }

--- a/api/evaluate-and-mint.js
+++ b/api/evaluate-and-mint.js
@@ -127,6 +127,7 @@ export default async function handler(req, res) {
     }
   }
 
+  const t0 = Date.now();
   let tier;
   let tierName;
   try {
@@ -134,18 +135,25 @@ export default async function handler(req, res) {
     tier = tierResult.tier;
     tierName = tierResult.tierName;
   } catch (scoreError) {
+    const latencyMs = Date.now() - t0;
+    // METRIC: evaluate-and-mint score resolution failure
+    console.log(`[metric] evaluate-and-mint latency=${latencyMs}ms score_error="${scoreError?.message}"`);
     return res.status(500).json({
       status: "error",
       message: scoreError?.message || "No se pudo validar el nivel para mintear",
     });
   }
-  
+
   if (tier >= 1) {
     const mintResult = await mintNftOnChain(userAddress, tier);
+    const latencyMs = Date.now() - t0;
     if (mintResult.success) {
+      // METRIC: successful mint conversion
+      console.log(`[metric] evaluate-and-mint latency=${latencyMs}ms tier=${tier} status=minted`);
       return res.json({ txHash: mintResult.hash, tier, tierName, status: "minted" });
     }
-
+    // METRIC: mint transaction failure
+    console.log(`[metric] evaluate-and-mint latency=${latencyMs}ms tier=${tier} status=tx_failed error="${mintResult.error}"`);
     return res.status(500).json({
       status: "error",
       tier,
@@ -154,6 +162,9 @@ export default async function handler(req, res) {
     });
   }
 
+  const latencyMs = Date.now() - t0;
+  // METRIC: user below minimum tier (no conversion)
+  console.log(`[metric] evaluate-and-mint latency=${latencyMs}ms tier=${tier} status=pending`);
   return res.json({
     message: "Nivel insuficiente",
     tier,

--- a/api/get-available-credit.js
+++ b/api/get-available-credit.js
@@ -22,6 +22,7 @@ export default async function handler(req, res) {
   const { userAddress } = req.body;
   if (!userAddress) return res.status(400).json({ error: "Falta wallet" });
 
+  const t0 = Date.now();
   try {
     const server = new rpc.Server(RPC_URL);
     const adminKeypair = Keypair.fromSecret(process.env.SECRET_KEY_ADMIN);
@@ -49,7 +50,10 @@ export default async function handler(req, res) {
     }
 
     const config = CREDIT_LIMITS[finalTier] || CREDIT_LIMITS[0];
-    
+    const latencyMs = Date.now() - t0;
+    // METRIC: get-available-credit latency and resolved tier
+    console.log(`[metric] get-available-credit latency=${latencyMs}ms tier=${finalTier} credit=${config.amount}XLM`);
+
     return res.status(200).json({
       success: true,
       tier: finalTier,
@@ -59,7 +63,10 @@ export default async function handler(req, res) {
     });
 
   } catch (error) {
+    const latencyMs = Date.now() - t0;
+    // METRIC: get-available-credit contract simulation failure
     console.error("Error get-available-credit:", error.message);
+    console.log(`[metric] get-available-credit latency=${latencyMs}ms error="${error.message}"`);
     return res.status(200).json({
       success: true,
       tier: 0,


### PR DESCRIPTION
- calculate-score: logs latency + tier eligibility on every call
- evaluate-and-mint: logs latency + mint status (minted/tx_failed/pending/score_error)
- get-available-credit: logs latency + resolved tier and credit amount

All hooks use console.log [metric] prefix for easy grep. No new dependencies. Removable in one pass.

Closes #35