### PR TITLE
feat: add anomaly threshold checks for scoring (#45)

### DIFF
--- a/api/calculate-score.js
+++ b/api/calculate-score.js
@@ -138,7 +138,24 @@ export default async function handler(req, res) {
 
     // Clamp a 0 para evitar valores negativos que corrompan retentionRate
     const result = computeFinancialReputation(history, Math.max(0, Number(effectiveTotal) || 0));
-    
+
+    // --- ANOMALY DETECTION ---
+    // Normal range: score 0–2000. Scores above 2000 indicate abnormal volume/retention
+    // and should be reviewed. Trigger: score > 2000 or retention > 5 (balance > 5x deposited).
+    // To simulate: send a wallet with totalDeposited=1 and a very high on-chain balance.
+    const SCORE_ANOMALY_THRESHOLD = 2000;
+    const RETENTION_ANOMALY_THRESHOLD = 5;
+    if (
+      result.score > SCORE_ANOMALY_THRESHOLD ||
+      (result.metrics && result.metrics.retention > RETENTION_ANOMALY_THRESHOLD)
+    ) {
+      console.warn(
+        `[ANOMALY] Unusual score detected for ${address}: score=${result.score}, retention=${result.metrics?.retention}. ` +
+        `Review thresholds in api/calculate-score.js (SCORE_ANOMALY_THRESHOLD, RETENTION_ANOMALY_THRESHOLD).`
+      );
+      result.anomaly = true;
+    }
+
     return res.status(200).json(result);
   } catch (error) {
     return res.status(500).json({ error: error.message });

--- a/api/evaluate-and-mint.js
+++ b/api/evaluate-and-mint.js
@@ -49,8 +49,13 @@ async function resolveTierFromCanonicalScore(req, userAddress, totalVolume) {
   const scoreData = await scoreResponse.json();
   const tier = Number(scoreData?.tier) || 0;
   const tierName = scoreData?.tierName || tierNameFromValue(tier);
+  const anomaly = scoreData?.anomaly === true;
 
-  return { tier, tierName };
+  if (anomaly) {
+    console.warn(`[ANOMALY] Flagged score during evaluate-and-mint for ${userAddress}. Minting blocked.`);
+  }
+
+  return { tier, tierName, anomaly };
 }
 
 async function mintNftOnChain(userAddress, tier) {
@@ -129,14 +134,25 @@ export default async function handler(req, res) {
 
   let tier;
   let tierName;
+  let anomaly = false;
   try {
     const tierResult = await resolveTierFromCanonicalScore(req, userAddress, effectiveTotalVolume);
     tier = tierResult.tier;
     tierName = tierResult.tierName;
+    anomaly = tierResult.anomaly || false;
   } catch (scoreError) {
     return res.status(500).json({
       status: "error",
       message: scoreError?.message || "No se pudo validar el nivel para mintear",
+    });
+  }
+
+  if (anomaly) {
+    return res.status(422).json({
+      status: "anomaly",
+      tier,
+      tierName,
+      message: "Score anómalo detectado. Minting bloqueado para revisión.",
     });
   }
   

--- a/src/components/CreditSection.tsx
+++ b/src/components/CreditSection.tsx
@@ -32,7 +32,7 @@ const getLendingContractId = () => {
 };
 
 const CreditSection = () => {
-  const { creditWithdrawn, withdrawCredit, deposits } = useApp();
+  const { creditWithdrawn, withdrawCredit, deposits, scoreAnomaly, setScoreAnomaly } = useApp();
   const { wallet } = useWallet();
   const [loadingTx, setLoadingTx] = useState(false); 
   const [loadingCredit, setLoadingCredit] = useState(true);
@@ -117,6 +117,7 @@ const CreditSection = () => {
             tier: data.tier,
             isUnlocked: data.tier >= 1 
           });
+          if (data.anomaly) setScoreAnomaly(true);
         }
         
       } catch (error) {
@@ -298,6 +299,13 @@ const CreditSection = () => {
           ON-CHAIN
         </div>
       </div>
+
+      {scoreAnomaly && (
+        <div className="mb-3 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg flex items-start gap-2 text-amber-600 text-xs animate-fade-in">
+          <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+          <p>Score anómalo detectado. Los datos serán revisados antes de habilitar operaciones.</p>
+        </div>
+      )}
 
       <div className="flex-1 flex flex-col justify-center">
         {creditWithdrawn ? (

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -48,6 +48,8 @@ interface AppContextType extends AppState {
   setShowSuccess: (v: boolean) => void;
   showUnlockCelebration: boolean;
   setShowUnlockCelebration: (v: boolean) => void;
+  scoreAnomaly: boolean;
+  setScoreAnomaly: (v: boolean) => void;
 }
 
 const STAKING_APY: Record<number, number> = {
@@ -79,6 +81,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   });
   const [showSuccess, setShowSuccess] = useState(false);
   const [showUnlockCelebration, setShowUnlockCelebration] = useState(false);
+  const [scoreAnomaly, setScoreAnomaly] = useState(false);
 
   const addDeposit = useCallback((amount: number) => {
     setState((prev) => {
@@ -165,6 +168,8 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
         setShowSuccess,
         showUnlockCelebration,
         setShowUnlockCelebration,
+        scoreAnomaly,
+        setScoreAnomaly,
       }}
     >
       {children}


### PR DESCRIPTION
Closes #45
  
  ## What this does
  Adds a lightweight anomaly signal to the scoring pipeline. When a score
  or retention ratio falls outside the expected normal range, the system
  logs a server-side warning, blocks minting, and shows an alert banner
  in the UI.
  
  ## Normal behavior
  - Score range: 0–~1000 for real testnet wallets (Platino is the ceiling).
  - Retention ratio: 0–1 (on-chain balance ≤ total ever deposited).
  - No `anomaly` field in the response → no banner, minting proceeds normally.
  
  ## Thresholds (api/calculate-score.js)
  | Constant                    | Value | Rationale                                      |
  |-----------------------------|-------|------------------------------------------------|
  | SCORE_ANOMALY_THRESHOLD     | 2000  | 2× above Platino; unreachable under normal use |
  | RETENTION_ANOMALY_THRESHOLD | 5     | Balance > 5× deposited is implausible          |
  
  ## Changes
  - **api/calculate-score.js** — checks both thresholds, emits `console.warn`,
    adds `anomaly: true` to the response JSON.
  - **api/evaluate-and-mint.js** — reads the flag; returns HTTP 422
    (`status: "anomaly"`) and blocks minting when set.
  - **src/context/AppContext.tsx** — exposes `scoreAnomaly / setScoreAnomaly`
    globally.
  - **src/components/CreditSection.tsx** — reads `data.anomaly` from the
    polling response and renders an amber AlertCircle banner.
  
  ## How to simulate the trigger
  ```bash
  curl -X POST http://localhost:3000/api/calculate-score \
    -H 'Content-Type: application/json' \
    -d '{"address": "<any_testnet_wallet_with_balance>", "totalDeposited": 1}'
  
  If the wallet's on-chain balance exceeds 5 XLM, retention > 5 and the
  anomaly fires. Look for [ANOMALY] in the server log and "anomaly": true
  in the JSON response.
  
  Signal to watch after deploy
  
  Monitor server logs for [ANOMALY]. A spike for a single wallet or across
  many wallets in a short window is the operational signal to investigate.
  
  Threshold review note
  
  Both constants are at the top of api/calculate-score.js with inline
  comments. Re-evaluate them in a future PR once a baseline of real score
  distributions is available from production traffic.
  
