### PR TITLE
feat(i18n): add language selector with EN/ES toggle and localStorage …

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,0 +1,34 @@
+import { Globe } from "lucide-react";
+import { useLanguage } from "@/i18n/useLanguage";
+
+const LABELS: Record<string, string> = {
+  es: "Español",
+  en: "English",
+};
+
+const LanguageSelector = () => {
+  const { language, supportedLanguages, changeLanguage } = useLanguage();
+
+  return (
+    <div className="flex items-center gap-2">
+      <Globe className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+      <div className="flex gap-1">
+        {supportedLanguages.map((lang) => (
+          <button
+            key={lang}
+            onClick={() => changeLanguage(lang)}
+            className={`px-3 py-1.5 rounded-lg text-xs font-bold transition-all active:scale-95 ${
+              language === lang
+                ? "bg-primary text-primary-foreground"
+                : "bg-secondary text-muted-foreground hover:bg-secondary/80"
+            }`}
+          >
+            {LABELS[lang] ?? lang.toUpperCase()}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default LanguageSelector;

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -15,25 +15,33 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import es from "./locales/es";
+import en from "./locales/en";
 
 export const DEFAULT_LANGUAGE = "es";
-export const SUPPORTED_LANGUAGES = ["es"] as const;
+export const SUPPORTED_LANGUAGES = ["es", "en"] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+const STORAGE_KEY = "vinculo_language";
+
+const savedLang = localStorage.getItem(STORAGE_KEY);
+const initialLang =
+  savedLang && (SUPPORTED_LANGUAGES as readonly string[]).includes(savedLang)
+    ? (savedLang as SupportedLanguage)
+    : DEFAULT_LANGUAGE;
 
 i18n.use(initReactI18next).init({
   resources: {
     es: { translation: es },
+    en: { translation: en },
   },
-  lng: DEFAULT_LANGUAGE,
+  lng: initialLang,
   fallbackLng: DEFAULT_LANGUAGE,
   supportedLngs: SUPPORTED_LANGUAGES,
 
   interpolation: {
-    // React already escapes values — no need for i18next to do it too
     escapeValue: false,
   },
 
-  // Return the key path when a translation is missing so nothing silently breaks
   parseMissingKeyHandler: (key) => key,
 });
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,0 +1,330 @@
+/**
+ * English (en) locale — mirrors es.ts structure exactly.
+ */
+
+const en = {
+  common: {
+    app_name: "Vyn",
+    app_tagline: "Stellar Microcredits",
+    loading: "Loading...",
+    error: "Error",
+    close: "Close",
+    cancel: "Cancel",
+    confirm: "Confirm",
+    save: "Save",
+    later: "Later",
+    done: "Done",
+    retry: "Try again",
+    back: "Back",
+    next: "Next",
+    skip: "Skip",
+    logout: "Log out",
+    wallet_connected: "Wallet connected",
+    wallet_not_connected: "Wallet not connected",
+    stellar_testnet: "Stellar Testnet",
+    xlm: "XLM",
+    footer_version: "Vyn v1.0 · Stellar Network",
+    footer_protocol: "Vyn Protocol · Decentralized",
+    footer_stellar: "Stellar Protocol · 2026",
+    view_on_network: "View on network",
+    receipt: "RECEIPT",
+    view_on_explorer: "View on explorer",
+  },
+
+  nav: {
+    home: "Home",
+    withdrawals: "Withdrawals",
+    history: "History",
+    profile: "Profile",
+  },
+
+  login: {
+    title: "Vínculo",
+    connect_freighter: "Connect with Freighter",
+    connect_albedo: "Connect with Albedo",
+    mobile_wallet_title: "Mobile wallet",
+    mobile_wallet_description:
+      "We'll use Albedo, a Stellar web wallet that works directly in your browser — no install needed.",
+    freighter_not_detected_title: "Freighter not detected",
+    freighter_not_detected_description:
+      "To use Vínculo on desktop you need the Freighter extension, or you can connect with Albedo directly.",
+    errors: {
+      cancelled: "Connection cancelled. You can try again whenever you're ready.",
+      popup_blocked:
+        "Popup was blocked. Allow popups for this site and try again.",
+      wallet_locked: "Your wallet is locked. Unlock it and try again.",
+      no_network: "No network connection. Check your internet and try again.",
+      generic:
+        "Connection error. Make sure your wallet is unlocked and try again.",
+    },
+  },
+
+  onboarding: {
+    cta_next: "Next",
+    cta_start: "Let's go!",
+    cta_skip: "Skip",
+    steps: {
+      save: {
+        title: "Save little by little 🐷",
+        description:
+          "Every week you save a portion of what you earn. It doesn't matter how small — consistency is what counts. You've got this!",
+      },
+      reputation: {
+        title: "Level up 🏆",
+        description:
+          "With 3 consecutive deposits you reach Silver Level. That proves you're trustworthy and opens incredible doors.",
+      },
+      credit: {
+        title: "Get your credit! 🎉",
+        description:
+          "Reaching Silver Level unlocks up to 300 XLM in credit. No paperwork, no queues — straight to your phone.",
+      },
+    },
+  },
+
+  home: {
+    deposit_button: "Deposit Earnings",
+    wallet_disconnected_title: "Wallet disconnected",
+    wallet_disconnected_description:
+      "Freighter is not available. Reconnect your wallet to operate.",
+    reconnect: "Reconnect",
+    loading_wallet: "Loading...",
+  },
+
+  balance: {
+    label: "MY SAVINGS",
+    subtitle: "Balance available in contract",
+    refresh_title: "Refresh balance",
+  },
+
+  credit: {
+    title: "Credit — Level {{tier}}",
+    badge_onchain: "ON-CHAIN",
+    locked_title: "Credit Locked 🔒",
+    locked_description:
+      "Your current level is {{tier}}. Claim your NFT to unlock.",
+    debt_label: "Total Amount Due",
+    expires_in: "Expires in: {{time}}",
+    withdraw_button: "Withdraw to my Wallet",
+    pay_button: "Pay {{amount}} XLM",
+    footer_network: "The withdrawal creates a transaction on the Stellar Testnet.",
+    footer_interest:
+      "Total due at maturity (1 month): {{amount}} XLM (Includes 5% interest)",
+    errors: {
+      no_liquidity:
+        "Not enough liquidity in the pool to disburse this amount right now. Try later or withdraw a smaller amount.",
+      active_loan:
+        "You already have an active loan. Pay it off before requesting a new one.",
+      tier_insufficient:
+        "Your current NFT doesn't enable this credit yet. Upgrade your level and try again.",
+      cancelled: "You cancelled the Freighter signature. No withdrawal was made.",
+      generic: "We couldn't process the withdrawal. Try again in a few seconds.",
+    },
+  },
+
+  deposit: {
+    title: "Deposit Earnings",
+    amount_label: "Amount (XLM)",
+    confirm_button: "Confirm with Freighter",
+    signing_title: "Preparing contract...",
+    signing_description:
+      "Calculating resources and waiting for Freighter confirmation.",
+    success_title: "Deposit successful! 🎉",
+    success_description: "{{amount}} XLM deposited",
+    view_explorer: "View on explorer",
+    sign_with: "Via {{provider}}",
+  },
+
+  activity: {
+    header: "Recent Activity",
+    empty_title_no_wallet: "Wallet not connected",
+    empty_title_no_activity: "No activity yet",
+    empty_description_no_wallet: "Connect Freighter to see your history",
+    empty_description_no_activity: "Make your first deposit to get started",
+    tx_deposit: "Deposit to Vínculo",
+    tx_withdrawal: "Credit Withdrawal",
+  },
+
+  wallet_setup: {
+    title: "Connect your wallet",
+    subtitle_albedo: "Via Albedo (web wallet)",
+    subtitle_freighter: "Via Freighter",
+    connect_albedo: "Connect with Albedo (web)",
+    connect_freighter: "Connect with Freighter",
+    freighter_not_detected: "Freighter not detected",
+    freighter_not_detected_description:
+      "Install the extension or continue with Albedo...",
+    error_cancelled: "Connection cancelled. You can try again.",
+    error_save: "Could not save. Try again.",
+  },
+
+  history: {
+    title: "History",
+    subtitle: "Last 40 transactions on Stellar",
+    syncing: "Syncing blockchain...",
+    empty_title_no_wallet: "Wallet not connected",
+    empty_title_no_txs: "No transactions",
+    empty_description_no_wallet: "Connect Freighter to see your history",
+    empty_description_no_txs: "Your deposits and withdrawals will appear here",
+    tx_deposit: "Deposit to Vínculo",
+    tx_withdrawal: "Credit Withdrawal",
+    summary_title: "Period Summary",
+    summary_deposits: "Deposits",
+    summary_volume_in: "Volume In",
+    summary_withdrawals: "Withdrawals",
+    summary_volume_out: "Volume Out",
+  },
+
+  profile: {
+    title: "Profile",
+    stat_savings: "XLM Savings",
+    stat_credit: "XLM Credit",
+    stat_nft_level: "NFT Level",
+    reputation_label: "Vínculo Reputation",
+    reputation_unlocked: "✓ LIMIT INCREASED",
+    reputation_locked: "Requires Silver Level",
+    reputation_max: "Maximum level reached",
+    reputation_progress: "{{percent}}% to next level",
+    reputation_activity_gate:
+      "Keep your activity to unlock reputation ({{current}}/{{required}})",
+    mint_button_default: "Evaluate and Level Up (NFT)",
+    mint_button_signing: "Signing on Soroban...",
+    mint_button_no_wallet: "Connect your wallet to mint",
+    mint_button_no_balance: "Deposit XLM to evaluate",
+    mint_button_max_tier: "Maximum level reached",
+    mint_button_already_has: "You already have {{tier}}. Wait for the next level",
+    max_tier_badge: "Maximum Level Reached 💎",
+    wallet_address_label: "Stellar Address",
+    menu_notifications: "Notifications",
+    menu_notifications_detail: "Enabled",
+    menu_help: "Help center",
+    menu_logout: "Log out",
+    toast_minted_title: "NFT minted successfully",
+    toast_minted_description: "You leveled up to {{level}}.",
+    toast_error_connection_title: "Unstable connection",
+    toast_error_connection_description:
+      "We couldn't connect to the Stellar network. Try again in a few seconds.",
+    mint_feedback: {
+      insufficient_level_title: "You haven't reached the next level yet",
+      insufficient_level_description: "Keep saving and try again.",
+      already_minted_title: "Level already minted",
+      already_minted_description:
+        "You already have the {{level}} NFT. Increase your reputation to mint the next level.",
+      generic_title: "Could not mint",
+      generic_description:
+        "We couldn't mint your NFT right now. Try again in a few seconds.",
+    },
+  },
+
+  withdrawals: {
+    title: "Withdrawals",
+    subtitle: "Send funds to your wallet",
+    available_balance: "Available balance",
+    withdraw_button: "Withdraw",
+    staking_section_title: "Staking",
+    staking_card_title: "Generate returns",
+    staking_card_description: "Lock your funds and earn interest",
+    staking_empty_title: "No staking positions",
+    staking_empty_description: "Choose a term above to start earning returns",
+    staking_active_label: "Active Position",
+    staking_locked_label: "Locked for {{months}} month(s)",
+    staking_apy_label: "{{apy}}% APY Generated",
+    staking_earnings_label: "Earnings",
+    staking_ready: "Ready to withdraw!",
+    staking_time_left: "{{minutes}}m {{seconds}}s remaining",
+    unstake_button: "Withdraw Investment",
+    modal_withdraw_title: "Withdraw funds",
+    modal_withdraw_subtitle: "Enter the amount you want to send to your wallet",
+    modal_confirm_button: "Confirm Withdrawal",
+    modal_all_button: "ALL",
+    modal_signing: "Processing...",
+    modal_success_title: "Withdrawal Successful",
+    modal_staking_title: "Staking",
+    modal_staking_confirm: "Lock Funds",
+    modal_staking_signing: "Processing on Soroban...",
+    modal_staking_signing_sub: "Confirm in Freighter",
+    modal_staking_success: "Transaction Successful!",
+    error_insufficient: "Insufficient balance",
+  },
+
+  notifications: {
+    title: "Notifications",
+    subtitle_unread: "{{count}} new today",
+    mark_all_read: "Mark all as read",
+    empty_title: "Empty inbox",
+    empty_description: "No news for now. We'll notify you of any changes!",
+    confirm_clear_all: "Delete all notifications?",
+    mock_deposit_title: "Deposit confirmed",
+    mock_deposit_message:
+      "Your 50 XLM are now in the smart contract generating reputation.",
+    mock_deposit_time: "2 hours ago",
+    mock_tier_title: "Silver Level available! 🥈",
+    mock_tier_message:
+      "Your score exceeded 50 pts. You can now claim your Silver Level NFT.",
+    mock_tier_time: "1 day ago",
+    mock_welcome_title: "Welcome to Vyn",
+    mock_welcome_message:
+      "Connect your Freighter to start building your financial history.",
+    mock_welcome_time: "3 days ago",
+  },
+
+  help: {
+    title: "Help Center",
+    support_title: "Have technical questions?",
+    support_description:
+      "If you have issues with Freighter or your transactions, write to us.",
+    faq_section_label: "Frequently Asked Questions",
+    resources_section_label: "Network Resources",
+    stellar_expert_title: "Stellar Expert",
+    stellar_expert_subtitle: "Testnet Explorer",
+    freighter_title: "Freighter Wallet",
+    freighter_subtitle: "Official help center",
+    faqs: [
+      {
+        q: "What is Vyn?",
+        a: "Vyn (Vínculo) is a DeFi platform that builds your financial identity on the blockchain. By saving in our smart contract, you generate a reputation score that gives you access to microcredits without traditional bureaucracy.",
+      },
+      {
+        q: "How do I level up?",
+        a: "Your level (Bronze, Silver, Gold...) depends on your Reputation Score. It's calculated by an algorithm that rewards the consistency of your deposits and how long you keep funds in the contract. Higher score means higher credit limit.",
+      },
+      {
+        q: "What are NFT levels?",
+        a: "Each level is a Soulbound Token (SBT). It's a special NFT tied to your wallet that can't be transferred or sold. It's your 'badge' as a good payer and saver on the Stellar network.",
+      },
+      {
+        q: "What network does Vyn operate on?",
+        a: "We currently operate on Stellar Testnet (Test Network). This lets you try all features without using real money while we complete the audit phase.",
+      },
+      {
+        q: "How do I withdraw my credit?",
+        a: "Once you reach Silver Level (50 reputation pts), the 'Withdraw Credit' option will automatically unlock in your profile. The amount will be sent directly to your Freighter wallet.",
+      },
+      {
+        q: "Are my funds safe?",
+        a: "Absolutely. Vyn uses Smart Contracts on Soroban (Stellar). Funds are locked under cryptographic rules that only you control with your digital signature in Freighter.",
+      },
+    ],
+  },
+
+  nft_modal: {
+    badge: "Accredited NFT",
+    title: "Congratulations!",
+    subtitle: "Your reputation NFT has been successfully minted on the Stellar network.",
+    meta_level: "Level Reached",
+    meta_deposits: "Deposit History",
+    meta_volume: "Protected Volume",
+    meta_owner: "Owner",
+    explorer_link: "View on StellarExpert",
+    accept_button: "Accept and Continue",
+    nft_alt: "NFT Level {{level}}",
+  },
+
+  not_found: {
+    title: "404",
+    message: "Oops! Page not found",
+    return_home: "Return to Home",
+  },
+} as const;
+
+export default en;

--- a/src/i18n/useLanguage.ts
+++ b/src/i18n/useLanguage.ts
@@ -3,26 +3,24 @@
  *
  * Usage:
  *   const { language, changeLanguage, supportedLanguages } = useLanguage();
- *
- * To add a new locale:
- *   1. Create src/i18n/locales/<lang>.ts
- *   2. Register it in src/i18n/config.ts
- *   3. Add the lang code to SUPPORTED_LANGUAGES in config.ts
- *   — changeLanguage() will work automatically.
  */
 
 import { useTranslation } from "react-i18next";
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from "./config";
 
+const STORAGE_KEY = "vinculo_language";
+
 export function useLanguage() {
   const { i18n } = useTranslation();
 
+  const changeLanguage = (lang: SupportedLanguage) => {
+    localStorage.setItem(STORAGE_KEY, lang);
+    return i18n.changeLanguage(lang);
+  };
+
   return {
-    /** Current active language code, e.g. "es" */
     language: i18n.language as SupportedLanguage,
-    /** All supported language codes */
     supportedLanguages: SUPPORTED_LANGUAGES,
-    /** Switch the active language. Resolves when resources are loaded. */
-    changeLanguage: (lang: SupportedLanguage) => i18n.changeLanguage(lang),
+    changeLanguage,
   };
 }

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -7,6 +7,7 @@ import { Shield, Wallet, Star, ChevronRight, LogOut, HelpCircle, Bell, Loader2, 
 import BottomNav from "@/components/BottomNav";
 import WalletSetupModal from "@/components/WalletSetupModal";
 import NFTModal from "@/components/NFTModal";
+import LanguageSelector from "@/components/LanguageSelector";
 import logoVin from "@/assets/logo-vin.png";
 import { toast } from "@/hooks/use-toast";
 import { requestAccess } from "@stellar/freighter-api";
@@ -445,6 +446,11 @@ const Perfil = () => {
               <p className="text-sm font-mono font-medium text-foreground break-all">{walletAddress}</p>
             </div>
           )}
+        </div>
+
+        {/* Language */}
+        <div className="card-elevated p-5 animate-fade-up" style={{ animationDelay: "380ms" }}>
+          <LanguageSelector />
         </div>
 
         {/* Menú */}


### PR DESCRIPTION
Summary
  
  Adds a language selector to the Profile page that lets users switch between
  Spanish and English. The selection is applied immediately and persisted across
  refreshes and new sessions via localStorage.
  
  Changes
  
  - src/i18n/locales/en.ts — Full English locale mirroring the existing es.ts
   structure (all namespaces: common, nav, login, onboarding, home, credit,
  deposit, activity, history, profile, withdrawals, notifications, help,
  nft_modal)
  - src/i18n/config.ts — Registers en resource; reads vinculo_language from
  localStorage on init to restore the saved preference
  - src/i18n/useLanguage.ts — changeLanguage() now writes to localStorage before
  delegating to i18next
  - src/components/LanguageSelector.tsx — Minimal ES / EN pill toggle,
  mobile-friendly, highlights the active language
  - src/pages/Perfil.tsx — Mounts LanguageSelector in a card above the settings
  menu
  
  How to test
  
  1. Open the app and go to Profile.
  2. Tap English — all translated strings switch immediately.
  3. Refresh the page — English is still active.
  4. Tap Español — switches back; refresh confirms persistence.
  5. Repeat on a mobile viewport.
  
  Acceptance criteria
  
  - [x] User can switch language in UI
  - [x] Selection persists across refresh and new session

close #8 
