### PR TITLE
feat: implement durable WS message replay log on reconnect

### DIFF
--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -1,0 +1,118 @@
+# WebSocket Streams — Durable Replay on Reconnect
+
+## Endpoint
+
+```
+GET /ws/streams
+Upgrade: websocket
+```
+
+### Query parameters
+
+| Parameter       | Type   | Required | Description                                                                 |
+|-----------------|--------|----------|-----------------------------------------------------------------------------|
+| `last_event_id` | number | No       | The `event_id` of the last event the client successfully processed. The server will replay all events with `event_id > last_event_id`. Defaults to `0` (full replay up to the cap) when absent or invalid. |
+
+**Example upgrade URL**
+
+```
+wss://api.example.com/ws/streams?last_event_id=1042
+```
+
+---
+
+## Message types
+
+All messages are JSON objects with a `type` field.
+
+### `replay`
+
+Sent once per missed event during the replay phase, in ascending `event_id` order.
+
+```json
+{
+  "type": "replay",
+  "event": {
+    "event_id": 1043,
+    "payload": { "...": "..." },
+    "created_at": "2026-05-30T18:00:00Z"
+  }
+}
+```
+
+### `replay_end`
+
+Sent once after all replay messages. Signals that the client is now in live mode.
+
+```json
+{
+  "type": "replay_end",
+  "replay_truncated": false
+}
+```
+
+`replay_truncated: true` means the gap exceeded `MAX_REPLAY_EVENTS` and some events were omitted. The client should treat its local state as potentially incomplete and consider a full re-sync.
+
+### `live`
+
+Sent for every new contract event that arrives after the replay phase.
+
+```json
+{
+  "type": "live",
+  "event": {
+    "event_id": 1100,
+    "payload": { "...": "..." },
+    "created_at": "2026-05-30T18:05:00Z"
+  }
+}
+```
+
+---
+
+## Reconnect flow
+
+```
+Client                              Server
+  |                                   |
+  |-- GET /ws/streams?last_event_id=N |
+  |                                   |-- query contract_events WHERE event_id > N
+  |<-- { type: "replay", event: ... } |   (up to MAX_REPLAY_EVENTS rows)
+  |<-- { type: "replay", event: ... } |
+  |<-- { type: "replay_end", ... }    |
+  |                                   |
+  |<-- { type: "live", event: ... }   |   (ongoing)
+```
+
+1. On every successful event the client should persist the latest `event_id` it has processed (e.g. in `localStorage` or a local DB).
+2. On reconnect, pass that value as `last_event_id`.
+3. Process all `replay` messages to fill the gap, then switch to live mode after `replay_end`.
+
+---
+
+## Configuration
+
+| Environment variable | Default | Description                                                  |
+|----------------------|---------|--------------------------------------------------------------|
+| `MAX_REPLAY_EVENTS`  | `200`   | Maximum number of events returned in a single replay window. |
+
+Set `MAX_REPLAY_EVENTS` in your `.env` / deployment config to tune the replay window for your workload.
+
+---
+
+## Security notes
+
+- **Authentication** — Apply your existing auth middleware to the `/ws/streams` upgrade handler before calling `attachHub`. The hub itself does not perform authentication.
+- **Input validation** — `last_event_id` is parsed as a non-negative integer. Any non-numeric, negative, or missing value is silently coerced to `0`.
+- **Replay cap** — `MAX_REPLAY_EVENTS` prevents unbounded database reads from a malicious or misconfigured client supplying `last_event_id=0` on a large dataset.
+- **No event filtering** — All events in the replay window are sent to the connected client. If events contain sensitive data, add row-level filtering in `getEventsSince` based on the authenticated user's identity.
+
+---
+
+## Source files
+
+| File | Purpose |
+|------|---------|
+| `src/ws/hub.ts` | WebSocket hub — `attachHub`, `handleConnection`, `broadcast` |
+| `src/db/repositories/contractEventRepository.ts` | `getEventsSince` DB query |
+| `src/ws/hub.replay.test.ts` | Unit tests |

--- a/src/db/repositories/contractEventRepository.ts
+++ b/src/db/repositories/contractEventRepository.ts
@@ -1,0 +1,49 @@
+/**
+ * contractEventRepository.ts
+ *
+ * Data-access layer for the `contract_events` table.
+ * The table schema is assumed to be:
+ *   contract_events (
+ *     event_id   BIGSERIAL PRIMARY KEY,
+ *     payload    JSONB NOT NULL,
+ *     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+ *   )
+ *
+ * The `db` parameter is a minimal query interface so the module stays
+ * testable without a real database connection.
+ */
+
+export interface ContractEvent {
+  event_id: number;
+  payload: Record<string, unknown>;
+  created_at: string;
+}
+
+/** Minimal DB interface — pass a real pg.Pool or a test double. */
+export interface DbClient {
+  query<T = unknown>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>;
+}
+
+/**
+ * Returns all contract_events with event_id > `afterEventId`, ordered
+ * ascending, capped at `limit` rows.
+ *
+ * @param db          - Database client
+ * @param afterEventId - Exclusive lower bound (the client's last seen id)
+ * @param limit        - Maximum rows to return (replay window cap)
+ */
+export async function getEventsSince(
+  db: DbClient,
+  afterEventId: number,
+  limit: number
+): Promise<ContractEvent[]> {
+  const { rows } = await db.query<ContractEvent>(
+    `SELECT event_id, payload, created_at
+       FROM contract_events
+      WHERE event_id > $1
+      ORDER BY event_id ASC
+      LIMIT $2`,
+    [afterEventId, limit]
+  );
+  return rows;
+}

--- a/src/ws/hub.replay.test.ts
+++ b/src/ws/hub.replay.test.ts
@@ -1,0 +1,242 @@
+/**
+ * hub.replay.test.ts
+ *
+ * Unit tests for the WebSocket replay bootstrap logic in src/ws/hub.ts.
+ *
+ * All external dependencies (DB, WebSocket) are replaced with lightweight
+ * in-process doubles so no network or database is required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { IncomingMessage } from "http";
+import type { WebSocket, WebSocketServer } from "ws";
+import {
+  handleConnection,
+  broadcast,
+  MAX_REPLAY_EVENTS,
+} from "./hub";
+import type { DbClient, ContractEvent } from "../db/repositories/contractEventRepository";
+
+// ── Test doubles ─────────────────────────────────────────────────────────────
+
+function makeEvent(id: number): ContractEvent {
+  return { event_id: id, payload: { id }, created_at: "2026-01-01T00:00:00Z" };
+}
+
+function makeDb(events: ContractEvent[]): DbClient {
+  return {
+    query: vi.fn().mockResolvedValue({ rows: events }),
+  };
+}
+
+function makeWs(readyState = 1): { ws: WebSocket; sent: unknown[] } {
+  const sent: unknown[] = [];
+  const ws = {
+    readyState,
+    send: vi.fn((data: string) => sent.push(JSON.parse(data))),
+    close: vi.fn(),
+  } as unknown as WebSocket;
+  return { ws, sent };
+}
+
+function makeReq(url: string): IncomingMessage {
+  return { url } as IncomingMessage;
+}
+
+// ── handleConnection ──────────────────────────────────────────────────────────
+
+describe("handleConnection", () => {
+  it("sends replay events then replay_end when events exist", async () => {
+    const events = [makeEvent(1), makeEvent(2), makeEvent(3)];
+    const db = makeDb(events);
+    const { ws, sent } = makeWs();
+
+    await handleConnection(ws, makeReq("/ws/streams?last_event_id=0"), db);
+
+    expect(sent).toHaveLength(4); // 3 replay + 1 replay_end
+    expect(sent[0]).toEqual({ type: "replay", event: events[0] });
+    expect(sent[1]).toEqual({ type: "replay", event: events[1] });
+    expect(sent[2]).toEqual({ type: "replay", event: events[2] });
+    expect(sent[3]).toEqual({ type: "replay_end", replay_truncated: false });
+  });
+
+  it("sends only replay_end with no events when history is empty", async () => {
+    const db = makeDb([]);
+    const { ws, sent } = makeWs();
+
+    await handleConnection(ws, makeReq("/ws/streams?last_event_id=99"), db);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({ type: "replay_end", replay_truncated: false });
+  });
+
+  it("passes last_event_id correctly to the DB query", async () => {
+    const db = makeDb([]);
+    const { ws } = makeWs();
+
+    await handleConnection(ws, makeReq("/ws/streams?last_event_id=42"), db);
+
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining("WHERE event_id > $1"),
+      [42, MAX_REPLAY_EVENTS + 1]
+    );
+  });
+
+  it("defaults last_event_id to 0 when param is absent", async () => {
+    const db = makeDb([]);
+    const { ws } = makeWs();
+
+    await handleConnection(ws, makeReq("/ws/streams"), db);
+
+    expect(db.query).toHaveBeenCalledWith(
+      expect.any(String),
+      [0, MAX_REPLAY_EVENTS + 1]
+    );
+  });
+
+  it("defaults last_event_id to 0 for non-numeric values", async () => {
+    const db = makeDb([]);
+    const { ws } = makeWs();
+
+    await handleConnection(ws, makeReq("/ws/streams?last_event_id=abc"), db);
+
+    expect(db.query).toHaveBeenCalledWith(expect.any(String), [0, expect.any(Number)]);
+  });
+
+  it("defaults last_event_id to 0 for negative values", async () => {
+    const db = makeDb([]);
+    const { ws } = makeWs();
+
+    await handleConnection(ws, makeReq("/ws/streams?last_event_id=-5"), db);
+
+    expect(db.query).toHaveBeenCalledWith(expect.any(String), [0, expect.any(Number)]);
+  });
+
+  it("sets replay_truncated=true and caps events when DB returns more than MAX_REPLAY_EVENTS", async () => {
+    // Simulate DB returning MAX_REPLAY_EVENTS + 1 rows (the over-fetch sentinel)
+    const events = Array.from({ length: MAX_REPLAY_EVENTS + 1 }, (_, i) =>
+      makeEvent(i + 1)
+    );
+    const db = makeDb(events);
+    const { ws, sent } = makeWs();
+
+    await handleConnection(ws, makeReq("/ws/streams?last_event_id=0"), db);
+
+    const replayMessages = sent.filter((m: any) => m.type === "replay");
+    const endMessage = sent.find((m: any) => m.type === "replay_end") as any;
+
+    expect(replayMessages).toHaveLength(MAX_REPLAY_EVENTS);
+    expect(endMessage.replay_truncated).toBe(true);
+  });
+
+  it("does not send when WebSocket is not open (readyState !== 1)", async () => {
+    const events = [makeEvent(1)];
+    const db = makeDb(events);
+    const { ws, sent } = makeWs(3 /* CLOSED */);
+
+    await handleConnection(ws, makeReq("/ws/streams?last_event_id=0"), db);
+
+    expect(sent).toHaveLength(0);
+  });
+
+  it("closes the socket on DB error", async () => {
+    const db: DbClient = {
+      query: vi.fn().mockRejectedValue(new Error("db down")),
+    };
+    const { ws } = makeWs();
+
+    // handleConnection itself rejects; the caller (attachHub) closes the socket.
+    await expect(
+      handleConnection(ws, makeReq("/ws/streams"), db)
+    ).rejects.toThrow("db down");
+  });
+
+  it("handles last_event_id at the boundary of available history (beyond max id)", async () => {
+    // Client supplies an id higher than any stored event → empty replay
+    const db = makeDb([]);
+    const { ws, sent } = makeWs();
+
+    await handleConnection(ws, makeReq("/ws/streams?last_event_id=999999"), db);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({ type: "replay_end", replay_truncated: false });
+  });
+
+  it("replay events are ordered ascending by event_id", async () => {
+    const events = [makeEvent(10), makeEvent(11), makeEvent(12)];
+    const db = makeDb(events);
+    const { ws, sent } = makeWs();
+
+    await handleConnection(ws, makeReq("/ws/streams?last_event_id=9"), db);
+
+    const replayMessages = sent.filter((m: any) => m.type === "replay") as any[];
+    const ids = replayMessages.map((m) => m.event.event_id);
+    expect(ids).toEqual([10, 11, 12]);
+  });
+});
+
+// ── broadcast ─────────────────────────────────────────────────────────────────
+
+describe("broadcast", () => {
+  it("sends a live message to all open clients", () => {
+    const { ws: ws1, sent: sent1 } = makeWs(1);
+    const { ws: ws2, sent: sent2 } = makeWs(1);
+    const wss = {
+      clients: new Set([ws1, ws2]),
+    } as unknown as WebSocketServer;
+
+    broadcast(wss, { foo: "bar" });
+
+    expect(sent1[0]).toEqual({ type: "live", event: { foo: "bar" } });
+    expect(sent2[0]).toEqual({ type: "live", event: { foo: "bar" } });
+  });
+
+  it("skips clients that are not open", () => {
+    const { ws: openWs, sent: openSent } = makeWs(1);
+    const { ws: closedWs, sent: closedSent } = makeWs(3);
+    const wss = {
+      clients: new Set([openWs, closedWs]),
+    } as unknown as WebSocketServer;
+
+    broadcast(wss, { x: 1 });
+
+    expect(openSent).toHaveLength(1);
+    expect(closedSent).toHaveLength(0);
+  });
+
+  it("does nothing when there are no clients", () => {
+    const wss = { clients: new Set() } as unknown as WebSocketServer;
+    expect(() => broadcast(wss, {})).not.toThrow();
+  });
+});
+
+// ── getEventsSince (repository unit) ─────────────────────────────────────────
+
+describe("getEventsSince", () => {
+  it("queries with correct SQL and parameters", async () => {
+    const { getEventsSince } = await import(
+      "../db/repositories/contractEventRepository"
+    );
+    const db = makeDb([makeEvent(5)]);
+
+    const result = await getEventsSince(db, 4, 10);
+
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining("WHERE event_id > $1"),
+      [4, 10]
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].event_id).toBe(5);
+  });
+
+  it("returns empty array when no events match", async () => {
+    const { getEventsSince } = await import(
+      "../db/repositories/contractEventRepository"
+    );
+    const db = makeDb([]);
+
+    const result = await getEventsSince(db, 100, 50);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/ws/hub.ts
+++ b/src/ws/hub.ts
@@ -1,0 +1,110 @@
+/**
+ * hub.ts — WebSocket connection hub with durable replay on reconnect.
+ *
+ * Upgrade endpoint: GET /ws/streams?last_event_id=<number>
+ *
+ * Reconnect flow:
+ *  1. Client supplies `last_event_id` in the upgrade query string.
+ *  2. Hub fetches all contract_events with event_id > last_event_id from the
+ *     database (capped at MAX_REPLAY_EVENTS).
+ *  3. Each missed event is sent as a `replay` message.
+ *  4. If the window was truncated a `replay_truncated` flag is set to true in
+ *     the final `replay_end` message.
+ *  5. The client then receives live events via `broadcast()`.
+ *
+ * Security:
+ *  - last_event_id is validated as a non-negative integer; invalid values
+ *    default to 0 (full replay up to the cap).
+ *  - MAX_REPLAY_EVENTS is configurable via the MAX_REPLAY_EVENTS env var and
+ *    defaults to 200, preventing unbounded DB reads.
+ *  - No authentication is added here; callers should apply auth middleware
+ *    before calling `handleUpgrade`.
+ */
+
+import type { IncomingMessage } from "http";
+import type { WebSocket, WebSocketServer } from "ws";
+import type { DbClient } from "../db/repositories/contractEventRepository";
+import { getEventsSince } from "../db/repositories/contractEventRepository";
+
+export const MAX_REPLAY_EVENTS: number =
+  Number(
+    typeof process !== "undefined" && process.env?.MAX_REPLAY_EVENTS
+      ? process.env.MAX_REPLAY_EVENTS
+      : 200
+  ) || 200;
+
+export interface HubDeps {
+  db: DbClient;
+  wss: WebSocketServer;
+}
+
+/** Wire the hub onto an existing WebSocketServer instance. */
+export function attachHub(deps: HubDeps): void {
+  deps.wss.on("connection", (ws: WebSocket, req: IncomingMessage) => {
+    handleConnection(ws, req, deps.db).catch((err) => {
+      console.error("[hub] connection error", err);
+      ws.close(1011, "internal error");
+    });
+  });
+}
+
+/** Exported for unit testing without a real WebSocketServer. */
+export async function handleConnection(
+  ws: WebSocket,
+  req: IncomingMessage,
+  db: DbClient
+): Promise<void> {
+  const lastEventId = parseLastEventId(req.url ?? "");
+
+  // ── Replay phase ──────────────────────────────────────────────────────────
+  // Fetch one extra row beyond the cap to detect truncation without a COUNT.
+  const fetchLimit = MAX_REPLAY_EVENTS + 1;
+  const events = await getEventsSince(db, lastEventId, fetchLimit);
+
+  const truncated = events.length > MAX_REPLAY_EVENTS;
+  const replayEvents = truncated ? events.slice(0, MAX_REPLAY_EVENTS) : events;
+
+  for (const event of replayEvents) {
+    send(ws, { type: "replay", event });
+  }
+
+  send(ws, { type: "replay_end", replay_truncated: truncated });
+
+  // ── Live phase ────────────────────────────────────────────────────────────
+  // The connection stays open; live events are pushed via broadcast().
+}
+
+/**
+ * Broadcast a live event to all connected clients.
+ * Call this whenever a new contract_event is persisted.
+ */
+export function broadcast(wss: WebSocketServer, event: unknown): void {
+  const payload = JSON.stringify({ type: "live", event });
+  wss.clients.forEach((client) => {
+    if (client.readyState === 1 /* OPEN */) {
+      client.send(payload);
+    }
+  });
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function parseLastEventId(url: string): number {
+  try {
+    // url may be a path+query string like "/ws/streams?last_event_id=42"
+    const search = url.includes("?") ? url.slice(url.indexOf("?")) : "";
+    const params = new URLSearchParams(search);
+    const raw = params.get("last_event_id");
+    if (raw === null) return 0;
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function send(ws: WebSocket, data: unknown): void {
+  if (ws.readyState === 1 /* OPEN */) {
+    ws.send(JSON.stringify(data));
+  }
+}


### PR DESCRIPTION
- Add getEventsSince(db, afterEventId, limit) to contractEventRepository.ts
- Add handleConnection with replay bootstrap and broadcast to hub.ts
  - Parses last_event_id query param (defaults to 0 for absent/invalid)
  - Fetches missed events from DB, sends as 'replay' messages
  - Caps replay at MAX_REPLAY_EVENTS (env var, default 200)
  - Sets replay_truncated flag in replay_end when window exceeded
- Add 16 unit tests in hub.replay.test.ts (17 total, all passing)
- Add docs/websocket.md documenting handshake, message types, and security

Closes #215