### PR TITLE
feat: structured logging and stress-test fixture

### DIFF
--- a/api/_logger.js
+++ b/api/_logger.js
@@ -1,0 +1,35 @@
+import { randomUUID } from "crypto";
+
+/**
+ * Minimal structured logger for Vercel serverless functions.
+ * Outputs newline-delimited JSON so log aggregators can parse fields directly.
+ * In local dev the output is still readable via `JSON.parse` or `jq`.
+ */
+
+function write(level, reqId, event, data) {
+  const entry = {
+    ts: new Date().toISOString(),
+    level,
+    reqId,
+    event,
+    ...data,
+  };
+  // Use process.stderr for errors so they surface in Vercel's error stream.
+  const stream = level === "error" ? process.stderr : process.stdout;
+  stream.write(JSON.stringify(entry) + "\n");
+}
+
+export function createLogger(req) {
+  // Honour any upstream request-id header (e.g. from Vercel's edge layer).
+  const reqId =
+    req?.headers?.["x-request-id"] ||
+    req?.headers?.["x-vercel-id"] ||
+    randomUUID();
+
+  return {
+    reqId,
+    info: (event, data = {}) => write("info", reqId, event, data),
+    warn: (event, data = {}) => write("warn", reqId, event, data),
+    error: (event, data = {}) => write("error", reqId, event, data),
+  };
+}

--- a/api/calculate-score.js
+++ b/api/calculate-score.js
@@ -1,3 +1,5 @@
+import { createLogger } from "./_logger.js";
+
 const HORIZON_URL = "https://horizon-testnet.stellar.org";
 // Para entornos de testnet reducimos el requisito para facilitar pruebas
 const MIN_TX_REQUIRED = 3;
@@ -5,7 +7,7 @@ const MIN_TX_REQUIRED = 3;
 const HISTORY_LIMIT = 30;
 
 // --- MOTOR DE REPUTACIÓN CALIBRADO (3000 XLM = 50 PTS) ---
-function computeFinancialReputation(history, totalBalance) {
+export function computeFinancialReputation(history, totalBalance) {
   if (history.length < MIN_TX_REQUIRED) {
     return {
       score: 0,
@@ -107,6 +109,8 @@ async function getCleanHistory(userAddress) {
 }
 
 export default async function handler(req, res) {
+  const log = createLogger(req);
+
   res.setHeader('Access-Control-Allow-Credentials', true);
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'POST,OPTIONS');
@@ -118,8 +122,11 @@ export default async function handler(req, res) {
   const { address, totalDeposited: clientTotalDeposited } = req.body;
   if (!address) return res.status(400).json({ error: "Wallet requerida" });
 
+  log.info("calculate_score.start", { address });
+
   try {
     const history = await getCleanHistory(address);
+    log.info("calculate_score.history_fetched", { address, count: history.length });
 
     // Preferimos usar el total enviado por cliente; si no, intentamos leer on-chain.
     let effectiveTotal = Number(clientTotalDeposited) || 0;
@@ -132,15 +139,23 @@ export default async function handler(req, res) {
           effectiveTotal = Number(native?.balance) || effectiveTotal;
         }
       } catch (e) {
-        // fallback a 0
+        log.warn("calculate_score.balance_fetch_failed", { address, err: e.message });
       }
     }
 
     // Clamp a 0 para evitar valores negativos que corrompan retentionRate
     const result = computeFinancialReputation(history, Math.max(0, Number(effectiveTotal) || 0));
-    
+
+    log.info("calculate_score.done", {
+      address,
+      score: result.score,
+      tier: result.tier,
+      tierName: result.tierName,
+    });
+
     return res.status(200).json(result);
   } catch (error) {
+    log.error("calculate_score.error", { address, err: error.message });
     return res.status(500).json({ error: error.message });
   }
 }

--- a/api/evaluate-and-mint.js
+++ b/api/evaluate-and-mint.js
@@ -6,14 +6,13 @@ import {
   Operation, 
   BASE_FEE, 
   nativeToScVal,
-  Transaction
 } from "@stellar/stellar-sdk";
 import dotenv from "dotenv";
+import { createLogger } from "./_logger.js";
 
 dotenv.config();
 
 const HORIZON_URL = "https://horizon-testnet.stellar.org";
-
 const RPC_URL = "https://soroban-testnet.stellar.org";
 const server = new rpc.Server(RPC_URL);
 
@@ -25,7 +24,7 @@ function tierNameFromValue(tier) {
   return "Bronce";
 }
 
-async function resolveTierFromCanonicalScore(req, userAddress, totalVolume) {
+async function resolveTierFromCanonicalScore(req, log, userAddress, totalVolume) {
   const host = req.headers["x-forwarded-host"] || req.headers.host;
   const proto = req.headers["x-forwarded-proto"] || "https";
 
@@ -33,9 +32,15 @@ async function resolveTierFromCanonicalScore(req, userAddress, totalVolume) {
     throw new Error("No se pudo resolver host para validar score");
   }
 
+  log.info("evaluate_and_mint.score_request", { userAddress, totalVolume, host });
+
   const scoreResponse = await fetch(`${proto}://${host}/api/calculate-score`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      // Propagate request-id so the inner call shares the same trace.
+      "x-request-id": log.reqId,
+    },
     body: JSON.stringify({
       address: userAddress,
       totalDeposited: Number(totalVolume) || 0,
@@ -50,10 +55,12 @@ async function resolveTierFromCanonicalScore(req, userAddress, totalVolume) {
   const tier = Number(scoreData?.tier) || 0;
   const tierName = scoreData?.tierName || tierNameFromValue(tier);
 
+  log.info("evaluate_and_mint.score_resolved", { userAddress, tier, tierName, score: scoreData?.score });
+
   return { tier, tierName };
 }
 
-async function mintNftOnChain(userAddress, tier) {
+async function mintNftOnChain(log, userAddress, tier) {
   try {
     const adminKeypair = Keypair.fromSecret(process.env.SECRET_KEY_ADMIN);
     const account = await server.getAccount(adminKeypair.publicKey());
@@ -63,7 +70,7 @@ async function mintNftOnChain(userAddress, tier) {
         networkPassphrase: Networks.TESTNET 
     })
       .addOperation(
-        Operation.invokeContractFunction({ // ✅ Nombre estándar
+        Operation.invokeContractFunction({
           contract: process.env.NFT_CONTRACT_ID,
           function: "mint", 
           args: [
@@ -79,27 +86,25 @@ async function mintNftOnChain(userAddress, tier) {
     transaction.sign(adminKeypair);
 
     const submitRes = await server.sendTransaction(transaction);
+    log.info("evaluate_and_mint.minted", { userAddress, tier, txHash: submitRes.hash });
     return { success: true, hash: submitRes.hash };
 
   } catch (error) {
-    console.error(`[DEBUG] 💥 Error Mint:`, error.message);
+    log.error("evaluate_and_mint.mint_failed", { userAddress, tier, err: error.message });
     return { success: false, error: error.message };
   }
 }
 
 export default async function handler(req, res) {
+  const log = createLogger(req);
+
   res.setHeader('Access-Control-Allow-Credentials', true);
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'POST,OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 
-  if (req.method === 'OPTIONS') {
-    return res.status(200).end();
-  }
-
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
-  }
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
 
   const { userAddress, deposits, totalVolume } = req.body || {};
 
@@ -107,13 +112,14 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: 'userAddress es requerido', status: 'error' });
   }
 
+  log.info("evaluate_and_mint.start", { userAddress });
+
   const fallbackVolumeFromDeposits = Array.isArray(deposits)
     ? deposits.reduce((acc, d) => acc + (Number(d?.amount) || 0), 0)
     : 0;
 
   let effectiveTotalVolume = Number(totalVolume) || fallbackVolumeFromDeposits;
 
-  // Si el cliente no provee un volumen válido, intentamos leer el saldo on-chain como fuente de verdad
   if (!effectiveTotalVolume || effectiveTotalVolume <= 0) {
     try {
       const resp = await fetch(`${HORIZON_URL}/accounts/${userAddress}`);
@@ -123,17 +129,18 @@ export default async function handler(req, res) {
         effectiveTotalVolume = Number(native?.balance) || effectiveTotalVolume;
       }
     } catch (e) {
-      // Si falla la consulta on-chain, usamos el fallback calculado desde 'deposits'
+      log.warn("evaluate_and_mint.balance_fetch_failed", { userAddress, err: e.message });
     }
   }
 
   let tier;
   let tierName;
   try {
-    const tierResult = await resolveTierFromCanonicalScore(req, userAddress, effectiveTotalVolume);
+    const tierResult = await resolveTierFromCanonicalScore(req, log, userAddress, effectiveTotalVolume);
     tier = tierResult.tier;
     tierName = tierResult.tierName;
   } catch (scoreError) {
+    log.error("evaluate_and_mint.score_error", { userAddress, err: scoreError?.message });
     return res.status(500).json({
       status: "error",
       message: scoreError?.message || "No se pudo validar el nivel para mintear",
@@ -141,7 +148,7 @@ export default async function handler(req, res) {
   }
   
   if (tier >= 1) {
-    const mintResult = await mintNftOnChain(userAddress, tier);
+    const mintResult = await mintNftOnChain(log, userAddress, tier);
     if (mintResult.success) {
       return res.json({ txHash: mintResult.hash, tier, tierName, status: "minted" });
     }
@@ -154,6 +161,7 @@ export default async function handler(req, res) {
     });
   }
 
+  log.info("evaluate_and_mint.insufficient_tier", { userAddress, tier, tierName });
   return res.json({
     message: "Nivel insuficiente",
     tier,

--- a/api/get-available-credit.js
+++ b/api/get-available-credit.js
@@ -1,4 +1,5 @@
 import { Keypair, rpc, TransactionBuilder, Networks, Operation, BASE_FEE, nativeToScVal, scValToNative } from "@stellar/stellar-sdk";
+import { createLogger } from "./_logger.js";
 
 const CREDIT_LIMITS = {
   0: { name: "Bronce", amount: 0 },
@@ -11,6 +12,8 @@ const CREDIT_LIMITS = {
 const RPC_URL = "https://soroban-testnet.stellar.org";
 
 export default async function handler(req, res) {
+  const log = createLogger(req);
+
   res.setHeader('Access-Control-Allow-Credentials', true);
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,PATCH,DELETE,POST,PUT');
@@ -21,6 +24,8 @@ export default async function handler(req, res) {
   
   const { userAddress } = req.body;
   if (!userAddress) return res.status(400).json({ error: "Falta wallet" });
+
+  log.info("get_available_credit.start", { userAddress });
 
   try {
     const server = new rpc.Server(RPC_URL);
@@ -49,7 +54,14 @@ export default async function handler(req, res) {
     }
 
     const config = CREDIT_LIMITS[finalTier] || CREDIT_LIMITS[0];
-    
+
+    log.info("get_available_credit.done", {
+      userAddress,
+      tier: finalTier,
+      tierName: config.name,
+      availableCredit: config.amount,
+    });
+
     return res.status(200).json({
       success: true,
       tier: finalTier,
@@ -59,7 +71,7 @@ export default async function handler(req, res) {
     });
 
   } catch (error) {
-    console.error("Error get-available-credit:", error.message);
+    log.error("get_available_credit.error", { userAddress, err: error.message });
     return res.status(200).json({
       success: true,
       tier: 0,

--- a/api/get-user-data.js
+++ b/api/get-user-data.js
@@ -1,10 +1,12 @@
 import { rpc, TransactionBuilder, Networks, Operation, BASE_FEE, nativeToScVal, scValToNative } from "@stellar/stellar-sdk";
+import { createLogger } from "./_logger.js";
 
 const CONTRACT_ID = "CAIYBGMKSA5V5EYUFKGD5OCWWS5M34YC7MKUKE3BOQE2WZP3R7A4S2D2";
 const RPC_URL = "https://soroban-testnet.stellar.org";
 
 export default async function handler(req, res) {
-  // Solo aceptamos GET
+  const log = createLogger(req);
+
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Método no permitido' });
   }
@@ -15,19 +17,19 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: 'Falta la dirección de la wallet' });
   }
 
+  log.info("get_user_data.start", { address });
+
   try {
     const server = new rpc.Server(RPC_URL);
     
-    // 1. Obtenemos la cuenta para poder armar la transacción de lectura
     let account;
     try {
       account = await server.getAccount(address);
     } catch (e) {
-      // Si la cuenta no existe en la red (wallet nueva sin fondear), el balance es 0
+      log.warn("get_user_data.account_not_found", { address });
       return res.status(200).json({ totalXlmDeposited: 0, depositCount: 0, nftLevel: 0 });
     }
 
-    // 2. Armamos la transacción simulada apuntando a get_balance
     const transaction = new TransactionBuilder(account, {
       fee: BASE_FEE,
       networkPassphrase: Networks.TESTNET,
@@ -36,15 +38,12 @@ export default async function handler(req, res) {
         Operation.invokeContractFunction({
           contract: CONTRACT_ID,
           function: "get_balance",
-          args: [
-            nativeToScVal(address, { type: "address" })
-          ],
+          args: [nativeToScVal(address, { type: "address" })],
         })
       )
       .setTimeout(30)
       .build();
 
-    // 3. Ejecutamos la simulación
     const response = await server.simulateTransaction(transaction);
 
     let balanceXLM = 0;
@@ -53,31 +52,26 @@ export default async function handler(req, res) {
       balanceXLM = Number(balanceInStroops) / 10000000;
     }
 
-    // --- LÓGICA DEL MOTOR DE NIVELES (El truco del hackathon) ---
-    // Determinamos el Nivel del NFT basados en el XLM depositado.
-    // Ajusta estos números (50, 150, 500) según la economía de tu app.
-    let nftLevel = 0; // Bronce por defecto
-    
-    if (balanceXLM >= 50) nftLevel = 1;   // Plata
-    if (balanceXLM >= 150) nftLevel = 2;  // Oro
-    if (balanceXLM >= 500) nftLevel = 3;  // Platino
-    if (balanceXLM >= 1000) nftLevel = 4; // Diamante
+    let nftLevel = 0;
+    if (balanceXLM >= 50) nftLevel = 1;
+    if (balanceXLM >= 150) nftLevel = 2;
+    if (balanceXLM >= 500) nftLevel = 3;
+    if (balanceXLM >= 1000) nftLevel = 4;
 
-    // Simulamos la cantidad de depósitos para la UI 
-    // (Si tiene saldo, asumimos al menos 1 depósito para que se vea actividad)
     let depositCount = balanceXLM > 0 ? 1 : 0;
     if (balanceXLM >= 150) depositCount = 3; 
     if (balanceXLM >= 500) depositCount = 10;
 
-    // 4. Devolvemos los datos listos para que Perfil.tsx los pinte
+    log.info("get_user_data.done", { address, balanceXLM, nftLevel, depositCount });
+
     return res.status(200).json({
       totalXlmDeposited: balanceXLM,
-      depositCount: depositCount,
-      nftLevel: nftLevel
+      depositCount,
+      nftLevel,
     });
 
   } catch (error) {
-    console.error("Error consultando la blockchain:", error);
+    log.error("get_user_data.error", { address, err: error.message });
     return res.status(500).json({ error: 'Error al comunicarse con Soroban' });
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:stress": "node scripts/stress-test.js"
   },
   "dependencies": {
     "@albedo-link/intent": "^0.13.0",

--- a/scripts/stress-test.js
+++ b/scripts/stress-test.js
@@ -1,0 +1,214 @@
+/**
+ * scripts/stress-test.js
+ *
+ * Deterministic fixture for the financial-reputation scoring engine.
+ * Runs entirely in-process — no network calls, no env vars required.
+ *
+ * Usage:
+ *   node scripts/stress-test.js
+ *   # or via npm:
+ *   npm run test:stress
+ *
+ * Seed data assumptions:
+ *   - Transaction dates are expressed as "N days before the moment the script
+ *     runs" so that time-decay weights are stable across runs (a deposit from
+ *     0 days ago always has weight 1, from 1 day ago always has weight 0.5,
+ *     etc.).  The absolute timestamps change each day, but the relative
+ *     distances — and therefore the tier outcomes — are identical on every run.
+ *   - Amounts are in XLM (same unit the API uses after Horizon parsing).
+ *   - "totalBalance" represents the current on-chain balance passed to the engine.
+ *   - Amounts are derived analytically from the scoring formula so the fixture
+ *     is self-documenting and reviewable without running it.
+ *
+ * Scoring formula (from api/calculate-score.js):
+ *   score = (weightedVolume × retentionRate × log10(txCount + 1)) / 60
+ *   weightedVolume = Σ deposit.amount × (1 / (daysAgo + 1))
+ *   retentionRate  = currentBalance / totalDeposited
+ *   drain penalty  : if balance < 10 % of deposited → score × 0.2
+ *
+ * Tier thresholds:
+ *   Plata    ≥  50   Oro  ≥ 150   Diamante ≥ 500   Platino ≥ 1000
+ *
+ * What this covers:
+ *   - Tier boundary conditions (Bronce → Plata → Oro → Diamante → Platino)
+ *   - Insufficient history guard (< 3 transactions)
+ *   - Account-drain penalty (balance < 10 % of deposited)
+ *   - Time-decay weighting (older deposits score lower than recent ones)
+ *   - Mixed deposit/withdrawal history
+ *
+ * What this does NOT cover:
+ *   - Horizon HTTP fetching (tested via integration / e2e)
+ *   - NFT minting (requires Soroban testnet + admin keypair)
+ */
+
+import { computeFinancialReputation } from "../api/calculate-score.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a Date that is `n` days before NOW.
+ * Using Date.now() keeps the relative time-decay weights stable across runs:
+ * daysAgo(0) always has weight 1/(0+1)=1, daysAgo(1) always has weight 0.5, etc.
+ */
+function daysAgo(n) {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+}
+
+function deposit(amount, daysBack) {
+  return { type: "deposit", amount, date: daysAgo(daysBack) };
+}
+
+function withdrawal(amount, daysBack) {
+  return { type: "withdrawal", amount, date: daysAgo(daysBack) };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture scenarios
+// ---------------------------------------------------------------------------
+
+const SCENARIOS = [
+  {
+    name: "insufficient_history",
+    description: "Only 2 transactions — below the 3-tx minimum",
+    history: [deposit(500, 1), deposit(500, 2)],
+    totalBalance: 1000,
+    expect: { tier: 0, tierName: "Bronce", isHistoryEligible: false },
+  },
+  {
+    name: "plata_boundary",
+    description: "Minimal activity that should land at Plata (tier 1, score ≥ 50)",
+    // 3 same-day deposits of 1661 XLM each, full retention.
+    // score = (3×1661×1 × 1 × log10(4)) / 60 ≈ 50.0
+    history: [deposit(1661, 0), deposit(1661, 0), deposit(1661, 0)],
+    totalBalance: 4983,
+    expect: { tier: 1, tierName: "Plata" },
+  },
+  {
+    name: "oro_boundary",
+    description: "Moderate activity landing at Oro (tier 2, score ≥ 150)",
+    // 5 same-day deposits of 2314 XLM each, full retention.
+    // score = (5×2314×1 × 1 × log10(6)) / 60 ≈ 150.0
+    history: Array.from({ length: 5 }, () => deposit(2314, 0)),
+    totalBalance: 11570,
+    expect: { tier: 2, tierName: "Oro" },
+  },
+  {
+    name: "diamante_boundary",
+    description: "High activity landing at Diamante (tier 3, score ≥ 500)",
+    // 10 same-day deposits of 2881 XLM each, full retention.
+    // score = (10×2881×1 × 1 × log10(11)) / 60 ≈ 500.0
+    history: Array.from({ length: 10 }, () => deposit(2881, 0)),
+    totalBalance: 28810,
+    expect: { tier: 3, tierName: "Diamante" },
+  },
+  {
+    name: "platino_boundary",
+    description: "Very high activity landing at Platino (tier 4, score ≥ 1000)",
+    // 20 same-day deposits of 2269 XLM each, full retention.
+    // score = (20×2269×1 × 1 × log10(21)) / 60 ≈ 1000.0
+    history: Array.from({ length: 20 }, () => deposit(2269, 0)),
+    totalBalance: 45380,
+    expect: { tier: 4, tierName: "Platino" },
+  },
+  {
+    name: "drain_penalty",
+    description: "Balance < 10 % of deposited — score should be penalised 80 % vs full retention",
+    // Without penalty: 3 deposits of 1661 XLM → Plata.
+    // With balance = 400 (< 10 % of 4983) the penalty fires → score × 0.2 → Bronce.
+    history: [deposit(1661, 0), deposit(1661, 0), deposit(1661, 0)],
+    totalBalance: 400,
+    expect: { tier: 0, tierName: "Bronce" },
+  },
+  {
+    name: "time_decay",
+    description: "Same amounts but old deposits should score lower than recent ones",
+    historyRecent: [deposit(3000, 0), deposit(3000, 1), deposit(3000, 2)],
+    historyOld:    [deposit(3000, 365), deposit(3000, 366), deposit(3000, 367)],
+    totalBalance: 9000,
+    // We only assert that recent > old, not exact values
+    expect: null,
+  },
+  {
+    name: "mixed_deposits_withdrawals",
+    description: "Withdrawals reduce retention rate and therefore the score",
+    history: [
+      deposit(5000, 0), deposit(5000, 1), deposit(5000, 2),
+      withdrawal(4000, 3), withdrawal(4000, 4),
+    ],
+    totalBalance: 2000,
+    expect: null, // just assert it runs without throwing
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`  ✗ FAIL: ${message}`);
+    failed++;
+  } else {
+    console.log(`  ✓ ${message}`);
+    passed++;
+  }
+}
+
+console.log("=== Vyn Financial Reputation — Stress-Test Fixture ===\n");
+
+for (const scenario of SCENARIOS) {
+  console.log(`[${scenario.name}] ${scenario.description}`);
+
+  if (scenario.name === "time_decay") {
+    // Special case: compare two runs
+    const recent = computeFinancialReputation(scenario.historyRecent, scenario.totalBalance);
+    const old    = computeFinancialReputation(scenario.historyOld,    scenario.totalBalance);
+    assert(
+      recent.score > old.score,
+      `recent score (${recent.score}) > old score (${old.score})`
+    );
+    console.log(`  recent=${recent.score} tier=${recent.tierName} | old=${old.score} tier=${old.tierName}`);
+    console.log();
+    continue;
+  }
+
+  const result = computeFinancialReputation(scenario.history, scenario.totalBalance);
+
+  // Always print the result for human review
+  console.log(`  score=${result.score} tier=${result.tier} (${result.tierName})`);
+  if (result.metrics) {
+    const m = result.metrics;
+    console.log(`  retention=${m.retention} activity=${m.activity} volumeIn=${m.volumeIn} volumeOut=${m.volumeOut}`);
+  }
+
+  if (scenario.expect) {
+    const e = scenario.expect;
+    if (e.tier !== undefined)    assert(result.tier === e.tier,         `tier === ${e.tier}`);
+    if (e.tierName !== undefined) assert(result.tierName === e.tierName, `tierName === "${e.tierName}"`);
+    if (e.isHistoryEligible !== undefined) {
+      assert(
+        result.eligibility.isHistoryEligible === e.isHistoryEligible,
+        `isHistoryEligible === ${e.isHistoryEligible}`
+      );
+    }
+  } else {
+    assert(typeof result.score === "number", "result.score is a number");
+  }
+
+  console.log();
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`=== Results: ${passed} passed, ${failed} failed ===`);
+
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Closes #34
Closes #44

---

## #34 — Structured logs and request traces

### What changed
- **`api/_logger.js`** — new shared module. `createLogger(req)` reads `x-request-id` / `x-vercel-id` from headers (Vercel sets these automatically) or generates a UUID fallback. Every line is newline-delimited JSON: `{ ts, level, reqId, event, ...data }`.
- **`api/calculate-score.js`** — logs `start`, `history_fetched`, `balance_fetch_failed`, `done`, `error`.
- **`api/evaluate-and-mint.js`** — logs `start`, `score_request`, `score_resolved`, `minted`, `mint_failed`, `score_error`, `insufficient_tier`. Propagates `x-request-id` to the inner `calculate-score` call so both legs share the same `reqId`.
- **`api/get-available-credit.js`** — logs `start`, `done`, `error`.
- **`api/get-user-data.js`** — logs `start`, `account_not_found`, `done`, `error`.

### Sample log output (local dev)
```json
{"ts":"2026-05-30T18:55:01.123Z","level":"info","reqId":"a1b2c3d4-...","event":"calculate_score.start","address":"GABC..."}
{"ts":"2026-05-30T18:55:01.340Z","level":"info","reqId":"a1b2c3d4-...","event":"calculate_score.history_fetched","address":"GABC...","count":12}
{"ts":"2026-05-30T18:55:01.341Z","level":"info","reqId":"a1b2c3d4-...","event":"calculate_score.done","address":"GABC...","score":52.4,"tier":1,"tierName":"Plata"}
```

### Before / after
- **Before:** `console.error(`[DEBUG] 💥 Error Mint:`, error.message)` — inconsistent, no request context.
- **After:** structured JSON with `reqId`, `event`, and `err` fields on every path.

---

## #44 — Stress-test fixture

### What changed
- **`api/calculate-score.js`** — `computeFinancialReputation` is now a named export so the fixture can import it without any HTTP or env setup.
- **`scripts/stress-test.js`** — 8 deterministic scenarios, zero network calls.
- **`package.json`** — added `test:stress` script.

### How to run
```bash
npm run test:stress
```

### Scenarios covered
| Scenario | What it proves |
|---|---|
| `insufficient_history` | < 3 txs → always Bronce, `isHistoryEligible: false` |
| `plata_boundary` | exact score ≈ 50 → tier 1 |
| `oro_boundary` | exact score ≈ 150 → tier 2 |
| `diamante_boundary` | exact score ≈ 500 → tier 3 |
| `platino_boundary` | exact score ≈ 1000 → tier 4 |
| `drain_penalty` | balance < 10 % of deposited → score × 0.2 → Bronce |
| `time_decay` | recent deposits score higher than old ones |
| `mixed_deposits_withdrawals` | withdrawals reduce retention rate, no crash |

### What the fixture does NOT cover
- Horizon HTTP fetching (requires integration / e2e environment)
- NFT minting (requires Soroban testnet + admin keypair)

### Seed data
Amounts are derived analytically from the scoring formula and documented inline in the script. Transaction dates are expressed as "N days before `Date.now()`" so time-decay weights are stable across runs.

---

## Validation
- `npm run test:stress` → 15/15 pass
- `npm test` (vitest) → 1/1 pass
- `npm run build` passes (API files are not bundled by Vite)