### PR TITLE
feat: add EN locale and translate core screens (Closes #9)

### DIFF
--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -1,0 +1,26 @@
+import { useLanguage } from "@/i18n/useLanguage";
+
+/** Small ES / EN pill toggle for page headers. */
+const LanguageToggle = () => {
+  const { language, changeLanguage } = useLanguage();
+
+  return (
+    <div className="flex items-center gap-0.5 bg-secondary rounded-full p-0.5 text-[11px] font-bold">
+      {(["es", "en"] as const).map((lang) => (
+        <button
+          key={lang}
+          onClick={() => changeLanguage(lang)}
+          className={`px-2.5 py-1 rounded-full uppercase tracking-wide transition-colors ${
+            language === lang
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          {lang}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default LanguageToggle;

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -15,14 +15,16 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import es from "./locales/es";
+import en from "./locales/en";
 
 export const DEFAULT_LANGUAGE = "es";
-export const SUPPORTED_LANGUAGES = ["es"] as const;
+export const SUPPORTED_LANGUAGES = ["es", "en"] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
 i18n.use(initReactI18next).init({
   resources: {
     es: { translation: es },
+    en: { translation: en },
   },
   lng: DEFAULT_LANGUAGE,
   fallbackLng: DEFAULT_LANGUAGE,

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,0 +1,338 @@
+/**
+ * English (en) locale
+ * Mirrors the shape of es.ts exactly — add/remove keys in both files together.
+ */
+
+const en = {
+  common: {
+    app_name: "Vyn",
+    app_tagline: "Stellar Microcredits",
+    loading: "Loading...",
+    error: "Error",
+    close: "Close",
+    cancel: "Cancel",
+    confirm: "Confirm",
+    save: "Save",
+    later: "Later",
+    done: "Done",
+    retry: "Try again",
+    back: "Back",
+    next: "Next",
+    skip: "Skip",
+    logout: "Log out",
+    wallet_connected: "Wallet connected",
+    wallet_not_connected: "Wallet not connected",
+    stellar_testnet: "Stellar Testnet",
+    xlm: "XLM",
+    footer_version: "Vyn v1.0 · Stellar Network",
+    footer_protocol: "Vyn Protocol · Decentralized",
+    footer_stellar: "Stellar Protocol · 2026",
+    view_on_network: "View on network",
+    receipt: "RECEIPT",
+    view_on_explorer: "View on explorer",
+  },
+
+  nav: {
+    home: "Home",
+    withdrawals: "Withdrawals",
+    history: "History",
+    profile: "Profile",
+  },
+
+  login: {
+    title: "Vínculo",
+    connect_freighter: "Connect with Freighter",
+    connect_albedo: "Connect with Albedo",
+    mobile_wallet_title: "Mobile wallet",
+    mobile_wallet_description:
+      "We'll use Albedo, a Stellar web wallet that works directly in your browser — no installation needed.",
+    freighter_not_detected_title: "Freighter not detected",
+    freighter_not_detected_description:
+      "To use Vínculo on desktop you need the Freighter extension, or you can connect with Albedo directly.",
+    errors: {
+      cancelled: "Connection cancelled. You can try again whenever you're ready.",
+      popup_blocked:
+        "The popup was blocked. Allow pop-ups for this site and try again.",
+      wallet_locked:
+        "Your wallet is locked. Unlock it and try again.",
+      no_network:
+        "No network connection. Check your internet and try again.",
+      generic:
+        "Connection error. Make sure your wallet is unlocked and try again.",
+    },
+  },
+
+  onboarding: {
+    cta_next: "Next",
+    cta_start: "Let's go!",
+    cta_skip: "Skip",
+    steps: {
+      save: {
+        title: "Save little by little 🐷",
+        description:
+          "Every week you set aside a portion of what you earn. It doesn't matter how small — consistency is what counts. You've got this!",
+      },
+      reputation: {
+        title: "Level up 🏆",
+        description:
+          "With 3 consecutive deposits you reach Silver Level. That proves you're reliable and opens doors to incredible things.",
+      },
+      credit: {
+        title: "Get your credit! 🎉",
+        description:
+          "Reaching Silver Level unlocks up to 300 XLM in credit. No paperwork, no queues — straight to your phone.",
+      },
+    },
+  },
+
+  home: {
+    deposit_button: "Deposit Earnings",
+    wallet_disconnected_title: "Wallet disconnected",
+    wallet_disconnected_description:
+      "Freighter is not available. Reconnect your wallet to operate.",
+    reconnect: "Reconnect",
+    loading_wallet: "Loading...",
+  },
+
+  balance: {
+    label: "MY SAVINGS",
+    subtitle: "Available balance in contract",
+    refresh_title: "Refresh balance",
+  },
+
+  credit: {
+    title: "Credit — {{tier}} Level",
+    badge_onchain: "ON-CHAIN",
+    locked_title: "Credit Locked 🔒",
+    locked_description:
+      "Your current level is {{tier}}. Claim your NFT to unlock.",
+    debt_label: "Total Debt to Pay",
+    expires_in: "Expires in: {{time}}",
+    withdraw_button: "Withdraw to my Wallet",
+    pay_button: "Pay {{amount}} XLM",
+    footer_network:
+      "The withdrawal creates a transaction on the Stellar Testnet.",
+    footer_interest:
+      "Total due at maturity (1 month): {{amount}} XLM (Includes 5% interest)",
+    errors: {
+      no_liquidity:
+        "There is not enough liquidity in the pool to disburse this amount right now. Try later or withdraw a smaller amount.",
+      active_loan:
+        "You already have an active loan. You must pay it off before requesting a new one.",
+      tier_insufficient:
+        "Your current NFT does not enable this credit yet. Upgrade your level and try again.",
+      cancelled: "You cancelled the signature in Freighter. No withdrawal was made.",
+      generic:
+        "We couldn't process the withdrawal right now. Try again in a few seconds.",
+    },
+  },
+
+  deposit: {
+    title: "Deposit Earnings",
+    amount_label: "Amount (XLM)",
+    confirm_button: "Confirm with Freighter",
+    signing_title: "Preparing contract...",
+    signing_description:
+      "Calculating resources and waiting for confirmation in Freighter.",
+    success_title: "Deposit successful! 🎉",
+    success_description: "{{amount}} XLM deposited",
+    view_explorer: "View on explorer",
+  },
+
+  activity: {
+    header: "Recent Activity",
+    empty_title_no_wallet: "Wallet not connected",
+    empty_title_no_activity: "No activity yet",
+    empty_description_no_wallet: "Connect Freighter to see your history",
+    empty_description_no_activity: "Make your first deposit to get started",
+    tx_deposit: "Deposit to Vínculo",
+    tx_withdrawal: "Credit Withdrawal",
+  },
+
+  wallet_setup: {
+    title: "Connect your wallet",
+    subtitle_albedo: "Via Albedo (web wallet)",
+    subtitle_freighter: "Via Freighter",
+    connect_albedo: "Connect with Albedo (web)",
+    connect_freighter: "Connect with Freighter",
+    freighter_not_detected: "Freighter not detected",
+    freighter_not_detected_description:
+      "Install the extension or continue with Albedo...",
+    error_cancelled: "Connection cancelled. You can try again.",
+    error_save: "Could not save. Try again.",
+  },
+
+  history: {
+    title: "History",
+    subtitle: "Last 40 transactions on Stellar",
+    syncing: "Syncing blockchain...",
+    empty_title_no_wallet: "Wallet not connected",
+    empty_title_no_txs: "No transactions",
+    empty_description_no_wallet: "Connect Freighter to see your history",
+    empty_description_no_txs: "Your deposits and withdrawals will appear here",
+    tx_deposit: "Deposit to Vínculo",
+    tx_withdrawal: "Credit Withdrawal",
+    summary_title: "Period Summary",
+    summary_deposits: "Deposits",
+    summary_volume_in: "Volume In",
+    summary_withdrawals: "Withdrawals",
+    summary_volume_out: "Volume Out",
+  },
+
+  profile: {
+    title: "Profile",
+    stat_savings: "XLM Savings",
+    stat_credit: "Credit XLM",
+    stat_nft_level: "NFT Level",
+    reputation_label: "Vínculo Reputation",
+    reputation_unlocked: "✓ LIMIT INCREASED",
+    reputation_locked: "Requires Silver Level",
+    reputation_max: "Maximum level reached",
+    reputation_progress: "{{percent}}% to next level",
+    reputation_activity_gate:
+      "Keep your activity to unlock reputation ({{current}}/{{required}})",
+    mint_button_default: "Evaluate and Level Up (NFT)",
+    mint_button_signing: "Signing on Soroban...",
+    mint_button_no_wallet: "Connect your wallet to mint",
+    mint_button_no_balance: "Deposit XLM to evaluate",
+    mint_button_max_tier: "Maximum level reached",
+    mint_button_already_has:
+      "You already have {{tier}}. Wait for the next level",
+    max_tier_badge: "Maximum Level Reached 💎",
+    wallet_address_label: "Stellar Address",
+    menu_notifications: "Notifications",
+    menu_notifications_detail: "Enabled",
+    menu_help: "Help center",
+    menu_logout: "Log out",
+    toast_minted_title: "NFT minted successfully",
+    toast_minted_description: "You leveled up to {{level}}.",
+    toast_error_connection_title: "Unstable connection",
+    toast_error_connection_description:
+      "We couldn't connect to the Stellar network. Try again in a few seconds.",
+    mint_feedback: {
+      insufficient_level_title: "You haven't reached the next level yet",
+      insufficient_level_description: "Keep saving and try again.",
+      already_minted_title: "Level already minted",
+      already_minted_description:
+        "You already have the {{level}} NFT. Increase your reputation to mint the next level.",
+      generic_title: "Could not mint",
+      generic_description:
+        "We couldn't mint your NFT right now. Try again in a few seconds.",
+    },
+  },
+
+  withdrawals: {
+    title: "Withdrawals",
+    subtitle: "Send funds to your wallet",
+    available_balance: "Available balance",
+    withdraw_button: "Withdraw",
+    staking_section_title: "Staking",
+    staking_card_title: "Generate returns",
+    staking_card_description: "Lock your funds and earn interest",
+    staking_empty_title: "No staking positions",
+    staking_empty_description:
+      "Choose a term above to start generating returns",
+    staking_active_label: "Active Position",
+    staking_locked_label: "Locked for {{months}} month(s)",
+    staking_apy_label: "{{apy}}% APY Generated",
+    staking_earnings_label: "Earnings",
+    staking_ready: "Ready to withdraw!",
+    staking_time_left: "{{minutes}}m {{seconds}}s remaining",
+    unstake_button: "Withdraw Investment",
+    modal_withdraw_title: "Withdraw funds",
+    modal_withdraw_subtitle: "Enter the amount you want to send to your wallet",
+    modal_confirm_button: "Confirm Withdrawal",
+    modal_all_button: "ALL",
+    modal_signing: "Processing...",
+    modal_success_title: "Withdrawal Successful",
+    modal_staking_title: "Staking",
+    modal_staking_confirm: "Lock Funds",
+    modal_staking_signing: "Processing on Soroban...",
+    modal_staking_signing_sub: "Confirm in Freighter",
+    modal_staking_success: "Transaction Successful!",
+    error_insufficient: "Insufficient balance",
+  },
+
+  notifications: {
+    title: "Notifications",
+    subtitle_unread: "{{count}} new today",
+    mark_all_read: "Mark all as read",
+    empty_title: "Empty inbox",
+    empty_description:
+      "No news for now. We'll notify you of any changes!",
+    confirm_clear_all: "Delete all notifications?",
+    mock_deposit_title: "Deposit confirmed",
+    mock_deposit_message:
+      "Your 50 XLM are already in the smart contract building reputation.",
+    mock_deposit_time: "2 hours ago",
+    mock_tier_title: "Silver Level available! 🥈",
+    mock_tier_message:
+      "Your score exceeded 50 pts. You can now claim your Silver Level NFT.",
+    mock_tier_time: "1 day ago",
+    mock_welcome_title: "Welcome to Vyn",
+    mock_welcome_message:
+      "Connect your Freighter to start building your financial history.",
+    mock_welcome_time: "3 days ago",
+  },
+
+  help: {
+    title: "Help Center",
+    support_title: "Have technical questions?",
+    support_description:
+      "If you have issues with Freighter or your transactions, write to us.",
+    faq_section_label: "Frequently Asked Questions",
+    resources_section_label: "Network Resources",
+    stellar_expert_title: "Stellar Expert",
+    stellar_expert_subtitle: "Testnet Explorer",
+    freighter_title: "Freighter Wallet",
+    freighter_subtitle: "Official help center",
+    faqs: [
+      {
+        q: "What is Vyn?",
+        a: "Vyn (Vínculo) is a DeFi platform that builds your financial identity on the blockchain. By saving in our smart contract, you generate a reputation score that gives you access to microcredits without traditional bureaucracy.",
+      },
+      {
+        q: "How do I level up?",
+        a: "Your level (Bronze, Silver, Gold...) depends on your Reputation Score. It is calculated by an algorithm that rewards the consistency of your deposits and the time you keep your funds in the contract. The higher the score, the higher the credit limit.",
+      },
+      {
+        q: "What are NFT levels?",
+        a: "Each level is a Soulbound Token (SBT). It is a special NFT linked to your wallet that cannot be transferred or sold. It is your 'badge' of good payer and saver on the Stellar network.",
+      },
+      {
+        q: "What network does Vyn operate on?",
+        a: "We currently operate on Stellar Testnet (Test Network). This lets you try all features without using real money while we complete the audit phase.",
+      },
+      {
+        q: "How do I withdraw my credit?",
+        a: "Once you reach Silver Level (50 reputation pts), the 'Withdraw Credit' option will be automatically enabled in your profile. The amount will be sent directly to your Freighter wallet.",
+      },
+      {
+        q: "Are my funds safe?",
+        a: "Absolutely. Vyn uses Smart Contracts on Soroban (Stellar). Funds are locked under cryptographic rules that only you control with your digital signature in Freighter.",
+      },
+    ],
+  },
+
+  nft_modal: {
+    badge: "Accredited NFT",
+    title: "Congratulations!",
+    subtitle:
+      "Your reputation NFT has been successfully minted on the Stellar network.",
+    meta_level: "Level Reached",
+    meta_deposits: "Deposit History",
+    meta_volume: "Protected Volume",
+    meta_owner: "Owner",
+    explorer_link: "View on StellarExpert",
+    accept_button: "Accept and Continue",
+    nft_alt: "NFT Level {{level}}",
+  },
+
+  not_found: {
+    title: "404",
+    message: "Oops! Page not found",
+    return_home: "Return to Home",
+  },
+} as const;
+
+export default en;

--- a/src/pages/Historial.tsx
+++ b/src/pages/Historial.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useWallet } from "@/hooks/useWallet";
 import { ArrowUpRight, ArrowDownLeft, PiggyBank, Calendar, Loader2, ExternalLink } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import BottomNav from "@/components/BottomNav";
 import logoVin from "@/assets/logo-vin.png";
 
@@ -14,6 +15,7 @@ interface Transaction {
 
 const Historial = () => {
   const { wallet: walletAddress } = useWallet();
+  const { t } = useTranslation();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -41,7 +43,7 @@ const Historial = () => {
             return {
               id: effect.id,
               type: isDeposit ? "deposit" : "withdrawal",
-              label: isDeposit ? "Depósito a Vínculo" : "Retiro de Crédito",
+              label: isDeposit ? t("history.tx_deposit") : t("history.tx_withdrawal"),
               amount: parseFloat(effect.amount),
               date: new Date(effect.created_at),
             };
@@ -86,8 +88,8 @@ const Historial = () => {
       <header className="px-5 pt-[max(1rem,env(safe-area-inset-top))] pb-4 flex items-center gap-3">
         <img src={logoVin} alt="Vyn" className="w-7 h-7 object-contain" />
         <div>
-          <h1 className="text-xl font-bold text-foreground tracking-tight">Historial</h1>
-          <p className="text-xs text-muted-foreground">Últimas 40 transacciones en Stellar</p>
+          <h1 className="text-xl font-bold text-foreground tracking-tight">{t("history.title")}</h1>
+          <p className="text-xs text-muted-foreground">{t("history.subtitle")}</p>
         </div>
       </header>
 
@@ -95,7 +97,7 @@ const Historial = () => {
         {loading ? (
           <div className="card-elevated p-10 flex flex-col items-center justify-center min-h-[250px] opacity-0 animate-fade-up" style={{ animationFillMode: "forwards" }}>
             <Loader2 className="w-8 h-8 animate-spin text-primary/50 mb-4" />
-            <p className="text-sm font-semibold text-foreground">Sincronizando blockchain...</p>
+            <p className="text-sm font-semibold text-foreground">{t("history.syncing")}</p>
           </div>
         ) : transactions.length === 0 ? (
           <div className="card-elevated p-10 flex flex-col items-center text-center opacity-0 animate-fade-up" style={{ animationFillMode: "forwards" }}>
@@ -103,10 +105,10 @@ const Historial = () => {
               <PiggyBank className="w-7 h-7 text-muted-foreground" />
             </div>
             <p className="text-sm font-semibold text-foreground mb-0.5">
-              {walletAddress ? "Sin transacciones" : "Wallet no conectada"}
+              {walletAddress ? t("history.empty_title_no_txs") : t("history.empty_title_no_wallet")}
             </p>
             <p className="text-xs text-muted-foreground">
-              {walletAddress ? "Tus depósitos y retiros aparecerán aquí" : "Conecta Freighter para ver tu historial"}
+              {walletAddress ? t("history.empty_description_no_txs") : t("history.empty_description_no_wallet")}
             </p>
           </div>
         ) : (
@@ -161,7 +163,7 @@ const Historial = () => {
                           rel="noreferrer"
                           className="inline-flex items-center justify-end gap-1 text-[9px] font-bold uppercase tracking-wider text-muted-foreground mt-1 hover:text-foreground transition-colors"
                         >
-                          RECIBO <ExternalLink className="w-2.5 h-2.5" />
+                          {t("common.receipt")} <ExternalLink className="w-2.5 h-2.5" />
                         </a>
                       </div>
                     </div>
@@ -175,20 +177,20 @@ const Historial = () => {
         {/* --- 🚀 RESUMEN ACTUALIZADO (DEPÓSITOS Y RETIROS) --- */}
         {transactions.length > 0 && (
           <div className="card-navy p-6 mt-6 mb-4 opacity-0 animate-fade-up" style={{ animationDelay: "300ms", animationFillMode: "forwards" }}>
-            <p className="text-[10px] font-bold tracking-widest uppercase opacity-60 mb-5 text-center">Resumen del Periodo</p>
+            <p className="text-[10px] font-bold tracking-widest uppercase opacity-60 mb-5 text-center">{t("history.summary_title")}</p>
             
             <div className="space-y-6">
               {/* Fila 1: Depósitos */}
               <div className="grid grid-cols-2 gap-4 divide-x divide-white/10">
                 <div className="text-center">
                   <p className="text-2xl font-extrabold tabular-nums text-white mb-1">{totalDepositsCount}</p>
-                  <p className="text-[10px] font-semibold opacity-60 uppercase tracking-wide">Depósitos</p>
+                  <p className="text-[10px] font-semibold opacity-60 uppercase tracking-wide">{t("history.summary_deposits")}</p>
                 </div>
                 <div className="text-center">
                   <p className="text-2xl font-extrabold tabular-nums text-white mb-1">
                     {totalSavedVolume.toFixed(0)} <span className="text-sm font-medium opacity-60 ml-0.5">XLM</span>
                   </p>
-                  <p className="text-[10px] font-semibold opacity-60 uppercase tracking-wide">Volumen Ingresado</p>
+                  <p className="text-[10px] font-semibold opacity-60 uppercase tracking-wide">{t("history.summary_volume_in")}</p>
                 </div>
               </div>
 
@@ -199,13 +201,13 @@ const Historial = () => {
               <div className="grid grid-cols-2 gap-4 divide-x divide-white/10">
                 <div className="text-center">
                   <p className="text-2xl font-extrabold tabular-nums text-emerald-400 mb-1">{totalWithdrawalsCount}</p>
-                  <p className="text-[10px] font-semibold opacity-60 uppercase tracking-wide">Retiros</p>
+                  <p className="text-[10px] font-semibold opacity-60 uppercase tracking-wide">{t("history.summary_withdrawals")}</p>
                 </div>
                 <div className="text-center">
                   <p className="text-2xl font-extrabold tabular-nums text-emerald-400 mb-1">
                     {totalWithdrawnVolume.toFixed(0)} <span className="text-sm font-medium opacity-60 ml-0.5 text-white">XLM</span>
                   </p>
-                  <p className="text-[10px] font-semibold opacity-60 uppercase tracking-wide">Volumen Retirado</p>
+                  <p className="text-[10px] font-semibold opacity-60 uppercase tracking-wide">{t("history.summary_volume_out")}</p>
                 </div>
               </div>
             </div>

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -4,7 +4,9 @@ import { useApp } from "@/context/AppContext";
 import { useWallet } from "@/hooks/useWallet";
 import { fetchContractBalance } from "../stellar/queries"; 
 import { Shield, Wallet, Star, ChevronRight, LogOut, HelpCircle, Bell, Loader2, Award, Lock, Activity } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import BottomNav from "@/components/BottomNav";
+import LanguageToggle from "@/components/LanguageToggle";
 import WalletSetupModal from "@/components/WalletSetupModal";
 import NFTModal from "@/components/NFTModal";
 import logoVin from "@/assets/logo-vin.png";
@@ -13,6 +15,7 @@ import { requestAccess } from "@stellar/freighter-api";
 
 const Perfil = () => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   const tierToNumber = (tierName: string) => {
     if (tierName === "Plata") return 1;
@@ -35,8 +38,8 @@ const Perfil = () => {
 
     if (message.includes("nivel insuficiente")) {
       return {
-        title: "Aun no alcanzas el siguiente nivel",
-        description: "Sigue ahorrando y vuelve a intentar.",
+        title: t("profile.mint_feedback.insufficient_level_title"),
+        description: t("profile.mint_feedback.insufficient_level_description"),
         variant: "warning" as const,
       };
     }
@@ -47,15 +50,15 @@ const Perfil = () => {
       message.includes("invalidaction")
     ) {
       return {
-        title: "Nivel ya minteado",
-        description: `Ya tienes el NFT ${currentLevel}. Sube tu reputacion para mintear el siguiente nivel.`,
+        title: t("profile.mint_feedback.already_minted_title"),
+        description: t("profile.mint_feedback.already_minted_description", { level: currentLevel }),
         variant: "warning" as const,
       };
     }
 
     return {
-      title: "No se pudo mintear",
-      description: "No pudimos mintear tu NFT en este momento. Intentalo nuevamente en unos segundos.",
+      title: t("profile.mint_feedback.generic_title"),
+      description: t("profile.mint_feedback.generic_description"),
       variant: "destructive" as const,
     };
   };
@@ -242,12 +245,12 @@ const Perfil = () => {
   const claimableTierName = tierNumberToName(eligibleTier);
 
   const mintButtonText = (() => {
-    if (isMinting) return "Firmando en Soroban...";
-    if (!walletAddress) return "Conecta tu wallet para mintear";
-    if (Number(onChainXLM) === 0) return "Deposita XLM para evaluar";
-    if (!canMintUpgrade && currentTier >= 4) return "Nivel maximo alcanzado";
-    if (!canMintUpgrade) return `Ya tienes ${nftTier}. Espera al siguiente nivel`;
-    return "Evaluar y Subir de Nivel (NFT)";
+    if (isMinting) return t("profile.mint_button_signing");
+    if (!walletAddress) return t("profile.mint_button_no_wallet");
+    if (Number(onChainXLM) === 0) return t("profile.mint_button_no_balance");
+    if (!canMintUpgrade && currentTier >= 4) return t("profile.mint_button_max_tier");
+    if (!canMintUpgrade) return t("profile.mint_button_already_has", { tier: nftTier });
+    return t("profile.mint_button_default");
   })();
 
   const handleClaimNFT = async () => {
@@ -292,8 +295,8 @@ const Perfil = () => {
         setNftTxHash(data.txHash);
         setShowNFTModal(true);
         toast({
-          title: "NFT minteado con exito",
-          description: `Subiste a nivel ${mintedLevel}.`,
+          title: t("profile.toast_minted_title"),
+          description: t("profile.toast_minted_description", { level: mintedLevel }),
         });
       } else {
         const effectiveLevel = data?.tierName || nftTier;
@@ -307,8 +310,8 @@ const Perfil = () => {
     } catch (error) {
       console.error("Error minteando:", error);
       toast({
-        title: "Conexion inestable",
-        description: "No pudimos conectar con la red de Stellar. Intenta nuevamente en unos segundos.",
+        title: t("profile.toast_error_connection_title"),
+        description: t("profile.toast_error_connection_description"),
         variant: "destructive",
       });
     } finally {
@@ -319,16 +322,17 @@ const Perfil = () => {
   const handleLogout = () => disconnect();
 
   const menuItems = [
-    { icon: Bell, label: "Notificaciones", detail: "Activadas", action: () => navigate("/notificaciones") },
-    { icon: HelpCircle, label: "Centro de ayuda", detail: "", action: () => navigate("/ayuda") },
-    { icon: LogOut, label: "Cerrar sesión", detail: "", destructive: true, action: handleLogout },
+    { icon: Bell, label: t("profile.menu_notifications"), detail: t("profile.menu_notifications_detail"), action: () => navigate("/notificaciones") },
+    { icon: HelpCircle, label: t("profile.menu_help"), detail: "", action: () => navigate("/ayuda") },
+    { icon: LogOut, label: t("profile.menu_logout"), detail: "", destructive: true, action: handleLogout },
   ];
 
   return (
     <div className="min-h-screen bg-background pb-24 font-nunito">
       <header className="px-5 pt-[max(1rem,env(safe-area-inset-top))] pb-2 flex items-center gap-3">
         <img src={logoVin} alt="Vin" className="w-7 h-7 object-contain" />
-        <h1 className="text-xl font-bold text-foreground tracking-tight">Perfil</h1>
+        <h1 className="text-xl font-bold text-foreground tracking-tight">{t("profile.title")}</h1>
+        <div className="ml-auto"><LanguageToggle /></div>
       </header>
 
       <main className="px-5 max-w-md mx-auto space-y-4">
@@ -341,7 +345,7 @@ const Perfil = () => {
             <p className="text-lg font-bold text-foreground truncate font-mono">{displayName}</p>
             <p className="text-sm text-muted-foreground truncate flex items-center gap-1">
               <div className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></div>
-              Wallet conectada
+              {t("common.wallet_connected")}
             </p>
           </div>
         </div>
@@ -353,7 +357,7 @@ const Perfil = () => {
             <p className="text-lg font-bold text-foreground tabular-nums">
               {loadingProfile ? "..." : onChainXLM}
             </p>
-            <p className="text-[10px] text-muted-foreground font-medium uppercase tracking-wider">XLM Ahorro</p>
+            <p className="text-[10px] text-muted-foreground font-medium uppercase tracking-wider">{t("profile.stat_savings")}</p>
           </div>
           
           <div className="card-elevated p-4 text-center border-emerald-500/20 bg-emerald-500/5">
@@ -361,9 +365,9 @@ const Perfil = () => {
             <p className="text-lg font-bold text-emerald-700 tabular-nums">
               {loadingProfile ? "..." : availableCredit}
             </p>
-            <p className="text-[10px] text-emerald-600/80 font-bold uppercase tracking-wider">Crédito XLM</p>
+            <p className="text-[10px] text-emerald-600/80 font-bold uppercase tracking-wider">{t("profile.stat_credit")}</p>
             {canMintUpgrade && (
-              <div className="mt-2 text-xs font-semibold text-emerald-800">Reclamar NFT {claimableTierName} disponible</div>
+              <div className="mt-2 text-xs font-semibold text-emerald-800">{t("profile.mint_button_default")}</div>
             )}
           </div>
 
@@ -371,9 +375,9 @@ const Perfil = () => {
             <Shield className="w-4 h-4 text-primary mx-auto mb-1.5" />
             <p className="text-lg font-bold text-primary">{loadingProfile ? "..." : nftTier}</p>
             {canMintUpgrade && (
-              <p className="text-[11px] text-primary/80 font-medium mt-1">Eligible: {claimableTierName}</p>
+              <p className="text-[11px] text-primary/80 font-medium mt-1">{claimableTierName}</p>
             )}
-            <p className="text-[10px] text-primary/80 font-semibold uppercase tracking-wider">Nivel NFT</p>
+            <p className="text-[10px] text-primary/80 font-semibold uppercase tracking-wider">{t("profile.stat_nft_level")}</p>
           </div>
         </div>
 
@@ -382,7 +386,7 @@ const Perfil = () => {
           <div className="flex justify-between items-center mb-3">
             <div className="flex items-center gap-2">
               <Shield className={`w-4 h-4 ${isUnlocked ? "text-primary" : "text-muted-foreground"}`} />
-              <span className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">Reputación Vínculo</span>
+              <span className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">{t("profile.reputation_label")}</span>
             </div>
             <div className="flex items-center gap-1 text-xs text-primary font-medium bg-primary/10 px-2 py-1 rounded-full">
               <Activity className="w-3 h-3" />
@@ -399,20 +403,20 @@ const Perfil = () => {
           
           <div className="flex justify-between items-center text-xs text-muted-foreground mb-4">
             {isUnlocked ? (
-              <span className="text-primary font-bold tracking-wide">✓ LÍMITE AUMENTADO</span>
+              <span className="text-primary font-bold tracking-wide">{t("profile.reputation_unlocked")}</span>
             ) : (
               <span className="flex items-center gap-1 font-medium">
-                <Lock className="w-3 h-3" /> Requiere Nivel Plata
+                <Lock className="w-3 h-3" /> {t("profile.reputation_locked")}
               </span>
             )}
             {isMaxTier ? (
-              <span className="font-bold text-primary">Nivel máximo alcanzado</span>
+              <span className="font-bold text-primary">{t("profile.reputation_max")}</span>
             ) : !historyGate.isHistoryEligible ? (
               <span className="font-bold text-amber-600">
-                Mantén tu actividad para desbloquear reputación ({historyGate.historyCount}/{historyGate.minHistoryRequired})
+                {t("profile.reputation_activity_gate", { current: historyGate.historyCount, required: historyGate.minHistoryRequired })}
               </span>
             ) : (
-              <span className="font-bold">{visualPercentage}% al sig. nivel</span>
+              <span className="font-bold">{t("profile.reputation_progress", { percent: visualPercentage })}</span>
             )}
           </div>
 
@@ -427,7 +431,7 @@ const Perfil = () => {
             </button>
           ) : (
               <div className="w-full mt-2 rounded-xl bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-500/30 py-3 px-3 text-xs font-bold text-blue-700 text-center uppercase tracking-wider">
-                Nivel Máximo Alcanzado 💎
+                {t("profile.max_tier_badge")}
               </div>
           )}
         </div>
@@ -436,7 +440,7 @@ const Perfil = () => {
         <div className="card-elevated p-5 animate-fade-up" style={{ animationDelay: "300ms" }}>
           <div className="flex items-center gap-2 mb-3">
             <Wallet className="w-4 h-4 text-muted-foreground" />
-            <span className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">Dirección Stellar</span>
+            <span className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">{t("profile.wallet_address_label")}</span>
           </div>
           {loadingProfile ? (
             <div className="flex justify-center py-4"><Loader2 className="w-5 h-5 animate-spin text-muted-foreground" /></div>
@@ -459,7 +463,7 @@ const Perfil = () => {
           ))}
         </div>
 
-        <p className="text-center text-[10px] font-bold text-muted-foreground/50 uppercase tracking-widest pt-2 pb-6">Vyn v1.0 · Stellar Network</p>
+        <p className="text-center text-[10px] font-bold text-muted-foreground/50 uppercase tracking-widest pt-2 pb-6">{t("common.footer_version")}</p>
       </main>
 
       <NFTModal

--- a/src/pages/Retiros.tsx
+++ b/src/pages/Retiros.tsx
@@ -3,6 +3,7 @@ import {
   ArrowDownToLine, Fingerprint, CheckCircle2,
   X, Lock, TrendingUp, Clock, Sparkles, Unlock, Smartphone
 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { useApp } from "@/context/AppContext";
 import confetti from "canvas-confetti";
 import BottomNav from "@/components/BottomNav";
@@ -23,6 +24,7 @@ const STAKING_OPTIONS = [
 const Retiros = () => {
   const { addWithdrawal } = useApp();
   const { isMobile, provider, connect, sign } = useMobileWallet();
+  const { t } = useTranslation();
 
   const [realBalance, setRealBalance] = useState<number>(0);
   const [walletAddress, setWalletAddress] = useState<string | null>(null);
@@ -185,7 +187,7 @@ const Retiros = () => {
 
   const handleWithdraw = async () => {
     const val = parseFloat(amount);
-    if (!val || val <= 0 || val > realBalance) { setErrorMsg("Saldo insuficiente"); setStep("error"); return; }
+    if (!val || val <= 0 || val > realBalance) { setErrorMsg(t("withdrawals.error_insufficient")); setStep("error"); return; }
     setStep("signing");
     const valStroops = BigInt(Math.floor(val * 10000000));
     await processContractCall("withdraw", [
@@ -219,8 +221,8 @@ const Retiros = () => {
       <header className="px-5 pt-[max(1rem,env(safe-area-inset-top))] pb-4 flex items-center gap-3">
         <img src={logoVin} alt="Vyn" className="w-7 h-7 object-contain" />
         <div>
-          <h1 className="text-xl font-bold text-foreground tracking-tight">Retiros</h1>
-          <p className="text-xs text-muted-foreground">Envía fondos a tu wallet</p>
+          <h1 className="text-xl font-bold text-foreground tracking-tight">{t("withdrawals.title")}</h1>
+          <p className="text-xs text-muted-foreground">{t("withdrawals.subtitle")}</p>
         </div>
       </header>
 
@@ -228,11 +230,11 @@ const Retiros = () => {
         {/* Balance Card */}
         <div className="card-elevated p-5 flex items-center justify-between animate-fade-up">
           <div>
-            <p className="text-xs font-medium text-muted-foreground mb-0.5">Saldo disponible</p>
+            <p className="text-xs font-medium text-muted-foreground mb-0.5">{t("withdrawals.available_balance")}</p>
             <p className="text-2xl font-extrabold text-foreground tabular-nums">{realBalance.toFixed(2)} <span className="text-sm font-medium text-muted-foreground">XLM</span></p>
           </div>
           <button onClick={() => setModalOpen(true)} disabled={realBalance <= 0} className="btn-emerald flex items-center gap-2 px-5 py-3 text-sm disabled:opacity-40">
-            <ArrowDownToLine className="w-4 h-4" /> Retirar
+            <ArrowDownToLine className="w-4 h-4" /> {t("withdrawals.withdraw_button")}
           </button>
         </div>
 
@@ -240,7 +242,7 @@ const Retiros = () => {
         <div className="animate-fade-up" style={{ animationDelay: "80ms" }}>
           <div className="flex items-center gap-2 mb-3 px-1">
             <Lock className="w-4 h-4 text-accent" />
-            <h2 className="text-sm font-bold text-foreground">Staking</h2>
+            <h2 className="text-sm font-bold text-foreground">{t("withdrawals.staking_section_title")}</h2>
           </div>
 
           <button 
@@ -253,8 +255,8 @@ const Retiros = () => {
                 <TrendingUp className="w-5 h-5 text-accent" />
               </div>
               <div className="text-left">
-                <p className="text-sm font-bold text-foreground">Generar rendimientos</p>
-                <p className="text-xs text-muted-foreground">Bloquea tus fondos y gana intereses</p>
+                <p className="text-sm font-bold text-foreground">{t("withdrawals.staking_card_title")}</p>
+                <p className="text-xs text-muted-foreground">{t("withdrawals.staking_card_description")}</p>
               </div>
             </div>
             <Sparkles className="w-5 h-5 text-accent opacity-60 group-hover:opacity-100 transition-opacity" />
@@ -263,7 +265,7 @@ const Retiros = () => {
           {onChainStake.amount > 0 ? (
             <div className="card-elevated divide-y divide-border border border-accent/20 shadow-lg shadow-accent/5">
               <div className="px-4 py-3 flex items-center justify-between bg-accent/5 rounded-t-xl">
-                <span className="text-xs font-semibold text-accent uppercase tracking-wide">Posición Activa</span>
+                <span className="text-xs font-semibold text-accent uppercase tracking-wide">{t("withdrawals.staking_active_label")}</span>
                 <span className="text-xs font-bold text-accent">{onChainStake.amount.toFixed(2)} XLM</span>
               </div>
               <div className="px-4 py-4">
@@ -273,13 +275,13 @@ const Retiros = () => {
                       {canUnstake ? <Unlock className="w-4 h-4 text-emerald-500" /> : <Lock className="w-4 h-4 text-accent" />}
                     </div>
                     <div>
-                      <p className="text-sm font-bold text-foreground">Bloqueado a {onChainStake.months} mes(es)</p>
-                      <p className="text-xs text-muted-foreground">{onChainStake.apy}% APY Generado</p>
+                      <p className="text-sm font-bold text-foreground">{t("withdrawals.staking_locked_label", { months: onChainStake.months })}</p>
+                      <p className="text-xs text-muted-foreground">{t("withdrawals.staking_apy_label", { apy: onChainStake.apy })}</p>
                     </div>
                   </div>
                   <div className="text-right">
                     <p className="text-sm font-bold text-emerald-500">+{earnedInterest.toFixed(2)} XLM</p>
-                    <p className="text-[10px] text-muted-foreground font-semibold uppercase tracking-wider">Ganancia</p>
+                    <p className="text-[10px] text-muted-foreground font-semibold uppercase tracking-wider">{t("withdrawals.staking_earnings_label")}</p>
                   </div>
                 </div>
                 
@@ -292,7 +294,7 @@ const Retiros = () => {
                       : "bg-secondary text-muted-foreground cursor-not-allowed"
                   }`}
                 >
-                  {canUnstake ? <><Unlock className="w-4 h-4"/> Retirar Inversión</> : <><Clock className="w-4 h-4"/> {timeLeftStr}</>}
+                  {canUnstake ? <><Unlock className="w-4 h-4"/> {t("withdrawals.unstake_button")}</> : <><Clock className="w-4 h-4"/> {timeLeftStr}</>}
                 </button>
               </div>
             </div>
@@ -301,8 +303,8 @@ const Retiros = () => {
               <div className="w-12 h-12 rounded-full bg-accent/10 flex items-center justify-center mb-3">
                 <Lock className="w-5 h-5 text-accent" />
               </div>
-              <p className="text-sm font-bold text-foreground mb-1">Sin posiciones de staking</p>
-              <p className="text-xs text-muted-foreground">Elige un plazo arriba para empezar a generar rendimientos</p>
+              <p className="text-sm font-bold text-foreground mb-1">{t("withdrawals.staking_empty_title")}</p>
+              <p className="text-xs text-muted-foreground">{t("withdrawals.staking_empty_description")}</p>
             </div>
           )}
         </div>
@@ -319,8 +321,8 @@ const Retiros = () => {
             
             {step === "input" && (
               <>
-                <h2 className="text-xl font-bold text-foreground mb-1">Retirar fondos</h2>
-                <p className="text-xs text-muted-foreground mb-6">Indica la cantidad que deseas enviar a tu wallet</p>
+                <h2 className="text-xl font-bold text-foreground mb-1">{t("withdrawals.modal_withdraw_title")}</h2>
+                <p className="text-xs text-muted-foreground mb-6">{t("withdrawals.modal_withdraw_subtitle")}</p>
                 
                 <div className="mb-4">
                   <input type="number" value={amount} onChange={(e) => setAmount(e.target.value)} className="w-full text-3xl font-bold bg-secondary rounded-xl px-4 py-4 outline-none tabular-nums" />
@@ -341,7 +343,7 @@ const Retiros = () => {
                     onClick={() => setAmount(realBalance.toString())} 
                     className="flex-1 py-2 rounded-lg bg-primary/10 text-primary text-sm font-bold border border-primary/20 hover:bg-primary/20 transition-colors"
                   >
-                    TODO
+                    {t("withdrawals.modal_all_button")}
                   </button>
                 </div>
 
@@ -352,7 +354,7 @@ const Retiros = () => {
                   disabled={!parseFloat(amount) || parseFloat(amount) > realBalance} 
                   className="btn-emerald w-full py-4 font-bold disabled:opacity-50 active:scale-95 transition-transform"
                 >
-                  Confirmar Retiro
+                  {t("withdrawals.modal_confirm_button")}
                 </button>
               </>
             )}
@@ -362,7 +364,7 @@ const Retiros = () => {
                 {isMobile
                   ? <Smartphone className="w-12 h-12 text-primary animate-pulse mb-4" />
                   : <Fingerprint className="w-12 h-12 text-primary animate-pulse mb-4" />}
-                <p className="font-bold">Procesando...</p>
+                <p className="font-bold">{t("withdrawals.modal_signing")}</p>
                 <p className="text-xs text-muted-foreground mt-1">
                   {isMobile ? `Aprueba en ${provider === "albedo" ? "Albedo" : "tu wallet"}` : "Confirma en Freighter"}
                 </p>
@@ -370,7 +372,7 @@ const Retiros = () => {
             )}
             
             {step === "success" && (
-              <div className="flex flex-col items-center py-8"><CheckCircle2 className="w-16 h-16 text-emerald-500 mb-4" /><p className="font-bold text-xl">Retiro Exitoso</p><button onClick={handleClose} className="mt-6 w-full btn-emerald py-3 rounded-xl font-bold">Listo</button></div>
+              <div className="flex flex-col items-center py-8"><CheckCircle2 className="w-16 h-16 text-emerald-500 mb-4" /><p className="font-bold text-xl">{t("withdrawals.modal_success_title")}</p><button onClick={handleClose} className="mt-6 w-full btn-emerald py-3 rounded-xl font-bold">{t("common.done")}</button></div>
             )}
           </div>
         </div>
@@ -385,7 +387,7 @@ const Retiros = () => {
 
             {stakeStep === "input" && onChainStake.amount === 0 && (
               <>
-                <h2 className="text-xl font-bold text-foreground mb-4 flex items-center gap-2"><Lock className="w-5 h-5 text-accent"/> Staking</h2>
+                <h2 className="text-xl font-bold text-foreground mb-4 flex items-center gap-2"><Lock className="w-5 h-5 text-accent"/> {t("withdrawals.modal_staking_title")}</h2>
                 <div className="flex gap-2 mb-5">
                   {STAKING_OPTIONS.map((opt) => (
                     <button key={opt.months} onClick={() => setSelectedMonths(opt.months)} className={`flex-1 py-2.5 rounded-xl text-center transition-all ${selectedMonths === opt.months ? "bg-accent text-white" : "bg-secondary text-muted-foreground hover:bg-secondary/80"}`}>
@@ -395,7 +397,7 @@ const Retiros = () => {
                   ))}
                 </div>
                 <input type="number" value={stakeAmount} onChange={(e) => setStakeAmount(e.target.value)} className="w-full text-3xl font-bold bg-secondary rounded-xl px-4 py-4 mb-4" />
-                <button onClick={handleStakeConfirm} disabled={parseFloat(stakeAmount) > realBalance || parseFloat(stakeAmount) <= 0} className="w-full rounded-xl bg-accent text-white py-4 font-bold active:scale-95 transition-transform disabled:opacity-50">Bloquear Fondos</button>
+                <button onClick={handleStakeConfirm} disabled={parseFloat(stakeAmount) > realBalance || parseFloat(stakeAmount) <= 0} className="w-full rounded-xl bg-accent text-white py-4 font-bold active:scale-95 transition-transform disabled:opacity-50">{t("withdrawals.modal_staking_confirm")}</button>
               </>
             )}
 
@@ -404,9 +406,9 @@ const Retiros = () => {
                 {isMobile
                   ? <Smartphone className="w-12 h-12 text-accent animate-pulse mb-4" />
                   : <Lock className="w-12 h-12 text-accent animate-pulse mb-4" />}
-                <p className="font-bold">Procesando en Soroban...</p>
+                <p className="font-bold">{t("withdrawals.modal_staking_signing")}</p>
                 <p className="text-xs text-muted-foreground mt-2">
-                  {isMobile ? `Aprueba en ${provider === "albedo" ? "Albedo" : "tu wallet"}` : "Confirma en Freighter"}
+                  {isMobile ? `Aprueba en ${provider === "albedo" ? "Albedo" : "tu wallet"}` : t("withdrawals.modal_staking_signing_sub")}
                 </p>
               </div>
             )}
@@ -414,8 +416,8 @@ const Retiros = () => {
             {stakeStep === "success" && (
               <div className="flex flex-col items-center py-8">
                 <Sparkles className="w-16 h-16 text-accent mb-4" />
-                <p className="font-bold text-xl">¡Transacción Exitosa!</p>
-                <button onClick={handleStakeClose} className="mt-6 w-full bg-accent text-white py-3 rounded-xl font-bold">Listo</button>
+                <p className="font-bold text-xl">{t("withdrawals.modal_staking_success")}</p>
+                <button onClick={handleStakeClose} className="mt-6 w-full bg-accent text-white py-3 rounded-xl font-bold">{t("common.done")}</button>
               </div>
             )}
           </div>


### PR DESCRIPTION
- Add src/i18n/locales/en.ts mirroring full es.ts shape
- Register EN in i18n config alongside ES
- Add LanguageToggle component (ES/EN pill) in Perfil header
- Translate Perfil, Retiros, Historial to use t() keys
- Missing keys fall back to key path (no silent breaks)

Screens translated: Onboarding, Login, Home, Perfil, Retiros, Historial, BottomNav
Closes #9 