### PR TITLE
Add WalletConnect support for Stellar

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@albedo-link/intent": "^0.13.0",
     "@hookform/resolvers": "^3.10.0",
     "@lovable.dev/cloud-auth-js": "^0.0.3",
+    "@walletconnect/core": "^2.17.0",
+    "@walletconnect/universal-provider": "^2.17.0",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/src/components/WalletSetupModal.tsx
+++ b/src/components/WalletSetupModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/hooks/useAuth";
-import { Wallet, Loader2, CheckCircle2, AlertCircle, Smartphone, ExternalLink } from "lucide-react";
+import { Wallet, Loader2, CheckCircle2, AlertCircle, Smartphone, ExternalLink, Link2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useMobileWallet } from "@/hooks/useMobileWallet";
 
@@ -26,15 +26,16 @@ function friendlyError(
 
 const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
   const { user } = useAuth();
-  const { isMobile, isFreighterReady, connect } = useMobileWallet();
+  const { isMobile, isFreighterReady, connect, connectToProvider, availableProviders } = useMobileWallet();
   const { t } = useTranslation();
 
   const [saving, setSaving] = useState(false);
   const [connecting, setConnecting] = useState(false);
+  const [selectedProvider, setSelectedProvider] = useState<"freighter" | "albedo" | "walletconnect" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
   const [address, setAddress] = useState<string | null>(null);
-  const [walletProvider, setWalletProvider] = useState<"freighter" | "albedo" | null>(null);
+  const [walletProvider, setWalletProvider] = useState<"freighter" | "albedo" | "walletconnect" | null>(null);
 
   const handleConnect = async () => {
     setConnecting(true);
@@ -51,6 +52,26 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
     setAddress(result.address);
     setWalletProvider(result.provider);
     setConnecting(false);
+  };
+
+  const handleConnectToProvider = async (provider: "freighter" | "albedo" | "walletconnect") => {
+    setConnecting(true);
+    setError(null);
+    setSelectedProvider(provider);
+
+    const result = await connectToProvider(provider);
+
+    if (!result.ok) {
+      setError(friendlyError(result.error, result.cancelled, t));
+      setConnecting(false);
+      setSelectedProvider(null);
+      return;
+    }
+
+    setAddress(result.address);
+    setWalletProvider(result.provider);
+    setConnecting(false);
+    setSelectedProvider(null);
   };
 
   const handleSave = async () => {
@@ -81,7 +102,20 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
   const truncate = (addr: string) =>
     addr.length > 16 ? `${addr.slice(0, 8)}...${addr.slice(-6)}` : addr;
 
-  const providerLabel = isMobile ? "Albedo" : isFreighterReady ? "Freighter" : "Albedo";
+  const getProviderIcon = (provider: "freighter" | "albedo" | "walletconnect") => {
+    if (provider === "walletconnect") return <Link2 className="w-5 h-5" />;
+    if (provider === "freighter") return <Wallet className="w-5 h-5" />;
+    return <Smartphone className="w-5 h-5" />;
+  };
+
+  const getProviderLabel = (provider: "freighter" | "albedo" | "walletconnect") => {
+    if (provider === "walletconnect") return "WalletConnect";
+    if (provider === "freighter") return "Freighter";
+    return "Albedo";
+  };
+
+  const shouldShowMultipleProviders = isMobile || !isFreighterReady;
+  const showMultipleOptions = shouldShowMultipleProviders && availableProviders.length > 1;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/40 backdrop-blur-sm px-6">
@@ -103,7 +137,7 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
               <div>
                 <h2 className="text-lg font-bold text-foreground leading-tight">{t("wallet_setup.title")}</h2>
                 <p className="text-xs text-muted-foreground">
-                  {isMobile ? t("wallet_setup.subtitle_albedo") : t("wallet_setup.subtitle_freighter")}
+                  {walletProvider ? `via ${getProviderLabel(walletProvider)}` : t("wallet_setup.select_provider")}
                 </p>
               </div>
             </div>
@@ -114,11 +148,11 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
                 <p className="text-sm font-mono font-medium text-foreground">{truncate(address)}</p>
                 {walletProvider && (
                   <p className="text-[10px] text-muted-foreground mt-1 uppercase tracking-wide">
-                    via {walletProvider}
+                    via {getProviderLabel(walletProvider)}
                   </p>
                 )}
               </div>
-            ) : !isMobile && !isFreighterReady ? (
+            ) : !isMobile && !isFreighterReady && !showMultipleOptions ? (
               <div className="space-y-3">
                 <div className="rounded-xl bg-amber-500/10 border border-amber-500/20 px-4 py-3 text-center">
                   <p className="text-xs font-bold text-amber-700 mb-0.5">{t("wallet_setup.freighter_not_detected")}</p>
@@ -150,6 +184,36 @@ const WalletSetupModal = ({ onComplete }: WalletSetupModalProps) => {
                   <ExternalLink className="w-3 h-3" />
                   {t("wallet_setup.install_freighter_alt")}
                 </a>
+              </div>
+            ) : showMultipleOptions ? (
+              <div className="space-y-3">
+                {availableProviders.map((provider) => (
+                  <button
+                    key={provider}
+                    onClick={() => handleConnectToProvider(provider)}
+                    disabled={connecting && selectedProvider !== provider}
+                    className="w-full rounded-xl border-2 border-border bg-secondary/50 px-4 py-4 flex items-center gap-3 hover:bg-secondary transition-colors active:scale-[0.98] disabled:opacity-50"
+                  >
+                    <div className="text-primary flex-shrink-0">
+                      {connecting && selectedProvider === provider ? (
+                        <Loader2 className="w-5 h-5 animate-spin" />
+                      ) : (
+                        getProviderIcon(provider)
+                      )}
+                    </div>
+                    <div className="flex-1 text-left">
+                      <p className="text-sm font-semibold text-foreground">{getProviderLabel(provider)}</p>
+                      <p className="text-[11px] text-muted-foreground">
+                        {provider === "freighter" && "Extensión Freighter"}
+                        {provider === "albedo" && "Billetera web"}
+                        {provider === "walletconnect" && "Billetera móvil"}
+                      </p>
+                    </div>
+                    {connecting && selectedProvider === provider && (
+                      <span className="text-xs text-primary font-medium">{t("common.loading")}</span>
+                    )}
+                  </button>
+                ))}
               </div>
             ) : (
               <button

--- a/src/hooks/useMobileWallet.ts
+++ b/src/hooks/useMobileWallet.ts
@@ -2,16 +2,19 @@
  * useMobileWallet
  *
  * Thin React hook that wraps the connector abstraction and exposes:
- *  - connect()        → get public key (auto-picks provider)
- *  - sign(xdr)        → sign a transaction XDR
- *  - isMobile         → boolean
- *  - provider         → "freighter" | "albedo"
- *  - isFreighterReady → boolean (extension detected)
+ *  - connect()                    → get public key (auto-picks provider)
+ *  - connectToProvider(provider)  → connect to specific provider (Freighter, Albedo, WalletConnect)
+ *  - sign(xdr)                    → sign a transaction XDR
+ *  - isMobile                     → boolean
+ *  - provider                      → current provider ("freighter" | "albedo" | "walletconnect")
+ *  - isFreighterReady             → boolean (extension detected)
+ *  - availableProviders           → list of available providers for this environment
  */
 
 import { useState, useEffect } from "react";
 import {
   connectWallet,
+  connectWithProvider,
   signTransactionXdr,
   isMobileBrowser,
   isFreighterAvailable,
@@ -24,7 +27,7 @@ import {
 export function useMobileWallet() {
   const [isMobile] = useState<boolean>(() => isMobileBrowser());
   const [freighterReady, setFreighterReady] = useState<boolean>(false);
-  const [provider, setProvider] = useState<"freighter" | "albedo">(
+  const [provider, setProvider] = useState<"freighter" | "albedo" | "walletconnect">(
     getSavedProvider
   );
 
@@ -46,8 +49,26 @@ export function useMobileWallet() {
     return () => clearInterval(id);
   }, [isMobile]);
 
+  // Compute available providers based on environment
+  const availableProviders: ("freighter" | "albedo" | "walletconnect")[] = isMobile
+    ? ["albedo", "walletconnect"]
+    : freighterReady
+      ? ["freighter", "albedo", "walletconnect"]
+      : ["albedo", "walletconnect"];
+
   const connect = async (): Promise<ConnectResult> => {
     const result = await connectWallet();
+    if (result.ok) {
+      saveProvider(result.provider);
+      setProvider(result.provider);
+    }
+    return result;
+  };
+
+  const connectToProvider = async (
+    targetProvider: "freighter" | "albedo" | "walletconnect"
+  ): Promise<ConnectResult> => {
+    const result = await connectWithProvider(targetProvider);
     if (result.ok) {
       saveProvider(result.provider);
       setProvider(result.provider);
@@ -63,7 +84,9 @@ export function useMobileWallet() {
     isMobile,
     provider,
     isFreighterReady: freighterReady,
+    availableProviders,
     connect,
+    connectToProvider,
     sign,
   };
 }

--- a/src/lib/mobileWalletConnectors.ts
+++ b/src/lib/mobileWalletConnectors.ts
@@ -3,18 +3,19 @@
  *
  * Strategy:
  * - Desktop: Freighter browser extension (existing flow, unchanged)
- * - Mobile:  Albedo web wallet (works in any mobile browser via popup/redirect,
- *            already in package.json as @albedo-link/intent)
+ * - Mobile:  Multiple options:
+ *   - Albedo web wallet (works in any mobile browser via popup/redirect)
+ *   - WalletConnect (mobile-friendly wallet aggregator via QR code or deep links)
  *
- * Albedo is a standards-based Stellar web wallet that requires no app install
- * and supports both signing and public-key retrieval via a popup or redirect.
- * It is the safest non-lock-in choice: if a better mobile connector emerges
- * (e.g. WalletConnect for Stellar), only this file needs updating.
+ * Albedo is a standards-based Stellar web wallet that requires no app install.
+ * WalletConnect provides an additional mobile-friendly path for users with
+ * WalletConnect-compatible Stellar wallets.
  */
 
 import albedo from "@albedo-link/intent";
+import UniversalProvider from "@walletconnect/universal-provider";
 import * as FreighterAPI from "@stellar/freighter-api";
-import { Networks } from "@stellar/stellar-sdk";
+import { Networks, TransactionBuilder } from "@stellar/stellar-sdk";
 
 // ─── Environment detection ────────────────────────────────────────────────────
 
@@ -37,7 +38,7 @@ export async function isFreighterAvailable(): Promise<boolean> {
 // ─── Unified result types ─────────────────────────────────────────────────────
 
 export type ConnectResult =
-  | { ok: true; address: string; provider: "freighter" | "albedo" }
+  | { ok: true; address: string; provider: "freighter" | "albedo" | "walletconnect" }
   | { ok: false; cancelled: boolean; error: string };
 
 export type SignResult =
@@ -49,6 +50,22 @@ export type SignResult =
 export async function connectWallet(): Promise<ConnectResult> {
   if (!isMobileBrowser() && await isFreighterAvailable()) {
     return connectFreighter();
+  }
+  return connectAlbedo();
+}
+
+/**
+ * Connect to a specific provider.
+ * Allows the UI to explicitly choose between multiple mobile options (Albedo, WalletConnect).
+ */
+export async function connectWithProvider(
+  provider: "freighter" | "albedo" | "walletconnect"
+): Promise<ConnectResult> {
+  if (provider === "freighter") {
+    return connectFreighter();
+  }
+  if (provider === "walletconnect") {
+    return connectWalletConnect();
   }
   return connectAlbedo();
 }
@@ -98,14 +115,85 @@ async function connectAlbedo(): Promise<ConnectResult> {
   }
 }
 
+async function connectWalletConnect(): Promise<ConnectResult> {
+  try {
+    const provider = await UniversalProvider.init({
+      projectId: "c4def77ac8a2450a9ec57ceb434ce2b0", // Public projectId for Stellar
+      metadata: {
+        name: "Vinculo",
+        description: "Vinculo - Stellar Web App",
+        url: window.location.origin,
+        icons: [`${window.location.origin}/public/robots.txt`],
+      },
+    });
+
+    // Subscribe to session updates
+    provider.on("connect", () => {
+      console.log("WalletConnect connected");
+    });
+
+    provider.on("disconnect", () => {
+      console.log("WalletConnect disconnected");
+    });
+
+    // Connect to a wallet
+    const session = await provider.connect({
+      namespaces: {
+        stellar: {
+          methods: ["stellar_signMessage", "stellar_signAndSubmitXDR", "stellar_requestSigningXDR"],
+          chains: ["stellar:mainnet"],
+          events: ["stellar_event"],
+          rpcMap: {
+            mainnet: "https://horizon-testnet.stellar.org/",
+          },
+        },
+      },
+    });
+
+    // Get the first namespace's first account address
+    const accounts = session.namespaces.stellar?.accounts || [];
+    if (!accounts.length) {
+      return { ok: false, cancelled: false, error: "WalletConnect no devolvió una dirección." };
+    }
+
+    // Extract public key from account (format: stellar:mainnet:GBXXXX)
+    const address = accounts[0].split(":")[2];
+    if (!address) {
+      return { ok: false, cancelled: false, error: "No se pudo extraer la dirección de WalletConnect." };
+    }
+
+    // Store the session for later signing
+    sessionStorage.setItem("wc_session", JSON.stringify(session));
+
+    return { ok: true, address, provider: "walletconnect" };
+  } catch (err: any) {
+    const msg: string = err?.message ?? String(err);
+    const cancelled =
+      msg.toLowerCase().includes("rejected") ||
+      msg.toLowerCase().includes("cancel") ||
+      msg.toLowerCase().includes("closed") ||
+      msg.toLowerCase().includes("user rejected");
+    return {
+      ok: false,
+      cancelled,
+      error: cancelled
+        ? "Conexión cancelada. Puedes intentarlo de nuevo."
+        : `Error al conectar con WalletConnect: ${msg}`,
+    };
+  }
+}
+
 // ─── Sign transaction XDR ─────────────────────────────────────────────────────
 
 export async function signTransactionXdr(
   xdr: string,
-  provider: "freighter" | "albedo"
+  provider: "freighter" | "albedo" | "walletconnect"
 ): Promise<SignResult> {
   if (provider === "freighter") {
     return signWithFreighter(xdr);
+  }
+  if (provider === "walletconnect") {
+    return signWithWalletConnect(xdr);
   }
   return signWithAlbedo(xdr);
 }
@@ -158,17 +246,81 @@ async function signWithAlbedo(xdr: string): Promise<SignResult> {
   }
 }
 
+async function signWithWalletConnect(xdr: string): Promise<SignResult> {
+  try {
+    const sessionJson = sessionStorage.getItem("wc_session");
+    if (!sessionJson) {
+      return { ok: false, cancelled: false, error: "Sesión de WalletConnect no encontrada. Reconecta tu wallet." };
+    }
+
+    const provider = await UniversalProvider.init({
+      projectId: "c4def77ac8a2450a9ec57ceb434ce2b0",
+      metadata: {
+        name: "Vinculo",
+        description: "Vinculo - Stellar Web App",
+        url: window.location.origin,
+        icons: [`${window.location.origin}/public/robots.txt`],
+      },
+    });
+
+    // Restore the session
+    await provider.connect({ session: JSON.parse(sessionJson) });
+
+    // Get the account for the signing request
+    const accounts = provider.session?.namespaces.stellar?.accounts || [];
+    if (!accounts.length) {
+      return { ok: false, cancelled: false, error: "No se encontró cuenta en WalletConnect." };
+    }
+
+    const account = accounts[0]; // format: stellar:mainnet:GBXXXX
+
+    // Request signature using the Stellar RPC method
+    // The wallet will present a signing popup/confirmation
+    const result = await provider.request({
+      topic: provider.session!.topic,
+      chainId: "stellar:mainnet",
+      request: {
+        method: "stellar_signAndSubmitXDR",
+        params: {
+          xdr: xdr,
+          submit: false, // we submit ourselves for consistency
+        },
+      },
+    }) as any;
+
+    if (!result || !result.signedXdr) {
+      return { ok: false, cancelled: false, error: "WalletConnect no devolvió la transacción firmada." };
+    }
+
+    return { ok: true, signedXdr: result.signedXdr };
+  } catch (err: any) {
+    const msg: string = err?.message ?? String(err);
+    const cancelled =
+      msg.toLowerCase().includes("rejected") ||
+      msg.toLowerCase().includes("cancel") ||
+      msg.toLowerCase().includes("closed") ||
+      msg.toLowerCase().includes("user rejected");
+    return {
+      ok: false,
+      cancelled,
+      error: cancelled
+        ? "Firma cancelada. Puedes intentarlo de nuevo."
+        : `Error al firmar con WalletConnect: ${msg}`,
+    };
+  }
+}
+
 // ─── Persist / retrieve provider choice ──────────────────────────────────────
 
 const PROVIDER_KEY = "vinculo_wallet_provider";
 
-export function saveProvider(provider: "freighter" | "albedo"): void {
+export function saveProvider(provider: "freighter" | "albedo" | "walletconnect"): void {
   localStorage.setItem(PROVIDER_KEY, provider);
 }
 
-export function getSavedProvider(): "freighter" | "albedo" {
+export function getSavedProvider(): "freighter" | "albedo" | "walletconnect" {
   const saved = localStorage.getItem(PROVIDER_KEY);
-  if (saved === "freighter" || saved === "albedo") return saved;
+  if (saved === "freighter" || saved === "albedo" || saved === "walletconnect") return saved;
   // Default: if on mobile default to albedo, else freighter
   return isMobileBrowser() ? "albedo" : "freighter";
 }


### PR DESCRIPTION
- Added @walletconnect/core and @walletconnect/universal-provider dependencies
- Extended mobileWalletConnectors.ts with WalletConnect connection and signing
- Updated provider abstraction to support 'walletconnect' as a third option
- Enhanced useMobileWallet hook with connectToProvider() for explicit provider selection
- Updated WalletSetupModal to display multiple wallet options on mobile/fallback
- Maintain backward compatibility with existing Freighter and Albedo flows
- WalletConnect provides an additional mobile-friendly wallet aggregator option

Closes #73