### PR TITLE
feat(i18n): localized dates, numbers, and XLM formatting (Closes #71)

### DIFF
--- a/src/components/ActivityList.tsx
+++ b/src/components/ActivityList.tsx
@@ -5,6 +5,7 @@ import {
   PiggyBank, Loader2, ExternalLink,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { useFormatters } from "@/lib/format";
 import { fetchActivity, type ActivityItem, type ActivityKind } from "@/stellar/activity";
 
 // Estética por tipo de acción. Depósito/retiro de ahorro = USDC; préstamo/pago = XLM;
@@ -25,6 +26,7 @@ const ActivityList = () => {
   const [movements, setMovements] = useState<ActivityItem[]>([]);
   const [loading, setLoading] = useState(true);
   const { t } = useTranslation();
+  const { formatAmount, formatDate } = useFormatters();
 
   useEffect(() => {
     if (!walletAddress) {
@@ -100,7 +102,7 @@ const ActivityList = () => {
                 {d.kind === "mint" ? t("activity.tx_mint", { level: d.level }) : t(meta.labelKey)}
               </p>
               <p className="text-xs text-muted-foreground">
-                {d.date.toLocaleDateString("es-MX", { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" })}
+                {formatDate(d.date, { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" })}
               </p>
             </div>
 
@@ -109,7 +111,7 @@ const ActivityList = () => {
                 <span className="text-sm font-bold text-primary">{d.level}</span>
               ) : (
                 <span className={`text-sm font-bold tabular-nums ${meta.amountColor}`}>
-                  {d.sign}{d.amount.toFixed(2)} {d.currency}
+                  {d.sign}{formatAmount(d.amount, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} {d.currency}
                 </span>
               )}
               <a

--- a/src/components/CreditSection.tsx
+++ b/src/components/CreditSection.tsx
@@ -2,6 +2,7 @@ import { Lock, Sparkles, ArrowDownToLine, Loader2, Activity, ArrowUpFromLine, Ca
 import { useApp } from "@/context/AppContext";
 import { useWallet } from "@/hooks/useWallet";
 import { useTranslation } from "react-i18next";
+import { useFormatters } from "@/lib/format";
 import { useState, useEffect, useRef } from "react";
 import confetti from "canvas-confetti";
 
@@ -34,6 +35,7 @@ const getLendingContractId = () => {
 
 const CreditSection = () => {
   const { t } = useTranslation();
+  const { formatAmount } = useFormatters();
   const { creditWithdrawn, withdrawCredit, deposits, scoreAnomaly, setScoreAnomaly } = useApp();
   const { wallet } = useWallet();
   const [loadingTx, setLoadingTx] = useState(false);
@@ -327,7 +329,7 @@ const CreditSection = () => {
                 </div>
                 <p className="text-lg font-bold text-red-500">{t("credit.frozen_title")}</p>
                 <p className="text-xs text-red-400 mt-2">
-                  {t("credit.frozen_description")} <strong>{totalToPay.toFixed(2)} XLM</strong>.
+                  {t("credit.frozen_description")} <strong>{formatAmount(totalToPay, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} XLM</strong>.
                 </p>
               </div>
               <button
@@ -346,7 +348,7 @@ const CreditSection = () => {
                 <div className="flex items-center justify-center gap-2 mt-1">
                   <TrendingUp className="w-5 h-5 text-amber-500" />
                   <span className="text-4xl font-extrabold text-amber-500 tabular-nums">
-                    {totalToPay.toFixed(2)}
+                    {formatAmount(totalToPay, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                   </span>
                   <span className="text-lg font-bold text-amber-500/70">XLM</span>
                 </div>
@@ -379,7 +381,7 @@ const CreditSection = () => {
                   </>
                 ) : (
                   <>
-                    <ArrowUpFromLine className="w-4 h-4" /> {t("credit.pay_button", { amount: totalToPay.toFixed(2) })}
+                    <ArrowUpFromLine className="w-4 h-4" /> {t("credit.pay_button", { amount: formatAmount(totalToPay, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) })}
                   </>
                 )}
               </button>
@@ -390,7 +392,7 @@ const CreditSection = () => {
           <div className="py-2 flex flex-col items-center justify-center">
             <div className="flex items-baseline gap-1 mt-1 mb-1">
               <span className="text-4xl font-extrabold text-foreground tabular-nums tracking-tight">
-                {creditData.limit}
+                {formatAmount(creditData.limit)}
               </span>
               <span className="text-lg font-bold text-muted-foreground">XLM</span>
             </div>
@@ -422,7 +424,7 @@ const CreditSection = () => {
             <div className="text-[10px] text-center text-muted-foreground mt-4 space-y-1">
               <p>{t("credit.footer_network")}</p>
               <p className="font-semibold text-amber-500/80">
-                {t("credit.footer_interest", { amount: totalToPay.toFixed(2) })}
+                {t("credit.footer_interest", { amount: formatAmount(totalToPay, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) })}
               </p>
             </div>
           </div>

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { resolveLocale, formatAmount, formatDate } from "./format";
+
+describe("resolveLocale", () => {
+  it("passes through a supported language code", () => {
+    expect(resolveLocale("es")).toBe("es");
+    expect(resolveLocale("en")).toBe("en");
+  });
+
+  it("falls back to the default language for an unknown code", () => {
+    expect(resolveLocale("fr")).toBe("es");
+    expect(resolveLocale("")).toBe("es");
+  });
+});
+
+describe("formatAmount", () => {
+  it("formats the number differently per locale (values switch with locale)", () => {
+    // es groups with '.' and uses ',' for decimals; en is the reverse.
+    expect(formatAmount(1234.5, "es")).not.toBe(formatAmount(1234.5, "en"));
+    expect(formatAmount(1234.5, "en")).toBe("1,234.5");
+  });
+
+  it("does not mutate or misround the underlying precision it is asked for", () => {
+    expect(formatAmount(1234.567, "en", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })).toBe("1,234.57");
+  });
+
+  it("honors explicit fraction digits", () => {
+    expect(formatAmount(300, "en", { minimumFractionDigits: 2, maximumFractionDigits: 2 })).toBe("300.00");
+    expect(formatAmount(1500.9, "en", { maximumFractionDigits: 0 })).toBe("1,501");
+  });
+
+  it("returns a non-finite input unchanged instead of 'NaN'", () => {
+    expect(formatAmount("...", "en")).toBe("...");
+    expect(formatAmount(Number.NaN, "en")).toBe("NaN");
+  });
+});
+
+describe("formatDate", () => {
+  const date = new Date("2026-01-15T14:30:00Z");
+  const opts: Intl.DateTimeFormatOptions = {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  };
+
+  it("formats the date differently per locale", () => {
+    expect(formatDate(date, "es", opts)).not.toBe(formatDate(date, "en", opts));
+  });
+
+  it("accepts Date, ISO string, and epoch inputs equivalently", () => {
+    const fromString = formatDate("2026-01-15T14:30:00Z", "en", opts);
+    const fromEpoch = formatDate(date.getTime(), "en", opts);
+    expect(fromString).toBe(formatDate(date, "en", opts));
+    expect(fromEpoch).toBe(formatDate(date, "en", opts));
+  });
+
+  it("returns an unparseable input unchanged", () => {
+    expect(formatDate("not-a-date", "en", opts)).toBe("not-a-date");
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,87 @@
+/**
+ * Locale-aware formatting for dates, numbers, and on-chain balances (XLM/USDC).
+ *
+ * Why this exists: several views formatted values with a hardcoded `"es-MX"`
+ * locale or `Number.toFixed(...)`, so dates and numbers looked the same
+ * regardless of the language the user picked. These helpers format at render
+ * time only — they never mutate the underlying value, so amounts stay exact
+ * and accurate; only their presentation changes with the active language.
+ *
+ * The app's language codes ("es", "en") are valid BCP-47 subtags, so they are
+ * handed straight to the Intl APIs. `resolveLocale` guards against an
+ * unexpected code by falling back to the default language. To pin a specific
+ * region later (e.g. "es-MX"), change the mapping in one place here.
+ */
+
+import { useMemo } from "react";
+import {
+  DEFAULT_LANGUAGE,
+  SUPPORTED_LANGUAGES,
+  type SupportedLanguage,
+} from "@/i18n/config";
+import { useLanguage } from "@/i18n/useLanguage";
+
+/** Map an app language code to the BCP-47 locale used by the Intl APIs. */
+export function resolveLocale(language: string): string {
+  return (SUPPORTED_LANGUAGES as readonly string[]).includes(language)
+    ? language
+    : DEFAULT_LANGUAGE;
+}
+
+/**
+ * Format a numeric amount (XLM balance, USDC volume, score, …) for display.
+ * The value is coerced but never rounded in storage; a non-finite value (e.g.
+ * a not-yet-loaded string) is returned unchanged so the UI never shows "NaN".
+ *
+ * Defaults to 0–2 fraction digits. Pass explicit digits to match a specific
+ * column (e.g. `{ minimumFractionDigits: 2, maximumFractionDigits: 2 }` for XLM
+ * amounts, or `{ maximumFractionDigits: 0 }` for whole-unit volumes).
+ */
+export function formatAmount(
+  value: number | string,
+  language: string,
+  options: Intl.NumberFormatOptions = {},
+): string {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return String(value);
+  return new Intl.NumberFormat(resolveLocale(language), {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+    ...options,
+  }).format(n);
+}
+
+/**
+ * Format a date/time for display in the active locale. Accepts a Date, an ISO
+ * string, or an epoch value; an unparseable input is returned as-is rather
+ * than throwing or rendering "Invalid Date".
+ */
+export function formatDate(
+  value: Date | string | number,
+  language: string,
+  options: Intl.DateTimeFormatOptions = {},
+): string {
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return String(value);
+  return new Intl.DateTimeFormat(resolveLocale(language), options).format(d);
+}
+
+/**
+ * Hook that binds the formatters to the current language, so components can
+ * call `formatAmount(value, opts?)` / `formatDate(value, opts?)` without
+ * threading the locale through every call site. Re-memoized when the language
+ * changes, which is what makes a language switch reformat every value on screen.
+ */
+export function useFormatters() {
+  const { language } = useLanguage();
+  return useMemo(() => {
+    const lang: SupportedLanguage = language;
+    return {
+      locale: resolveLocale(lang),
+      formatAmount: (value: number | string, options?: Intl.NumberFormatOptions) =>
+        formatAmount(value, lang, options),
+      formatDate: (value: Date | string | number, options?: Intl.DateTimeFormatOptions) =>
+        formatDate(value, lang, options),
+    };
+  }, [language]);
+}

--- a/src/pages/Historial.tsx
+++ b/src/pages/Historial.tsx
@@ -6,6 +6,7 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import AppShell from "@/components/AppShell";
+import { useFormatters } from "@/lib/format";
 import { fetchActivity, type ActivityItem, type ActivityKind } from "@/stellar/activity";
 
 // Misma estética por tipo que ActivityList: ahorro USDC, crédito XLM, mint = nivel.
@@ -32,6 +33,7 @@ const TABS: { id: TabId; labelKey: string }[] = [
 const Historial = () => {
   const { wallet: walletAddress } = useWallet();
   const { t } = useTranslation();
+  const { formatAmount, formatDate } = useFormatters();
   const [items, setItems] = useState<ActivityItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [sbtLevel, setSbtLevel] = useState<string | null>(null);
@@ -92,7 +94,7 @@ const Historial = () => {
 
   // Agrupación por mes (sobre el filtrado).
   const grouped = filtered.reduce<Record<string, ActivityItem[]>>((acc, tx) => {
-    const key = tx.date.toLocaleDateString("es-MX", { month: "long", year: "numeric" });
+    const key = formatDate(tx.date, { month: "long", year: "numeric" });
     if (!acc[key]) acc[key] = [];
     acc[key].push(tx);
     return acc;
@@ -222,7 +224,7 @@ const Historial = () => {
                               {tx.kind === "mint" ? t("activity.tx_mint", { level: tx.level }) : t(meta.labelKey)}
                             </p>
                             <p className="text-xs font-medium text-muted-foreground mt-0.5">
-                              {tx.date.toLocaleDateString("es-MX", { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" })}
+                              {formatDate(tx.date, { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" })}
                             </p>
                           </div>
 
@@ -231,7 +233,7 @@ const Historial = () => {
                               <span className="block text-sm font-bold text-primary">{tx.level}</span>
                             ) : (
                               <span className={`block text-sm font-bold tabular-nums ${meta.amountColor}`}>
-                                {tx.sign}{tx.amount.toFixed(2)} {tx.currency}
+                                {tx.sign}{formatAmount(tx.amount, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} {tx.currency}
                               </span>
                             )}
                             <a
@@ -267,7 +269,7 @@ const Historial = () => {
                     </div>
                     <div className="text-center">
                       <p className="text-2xl font-extrabold tabular-nums text-white mb-1">
-                        {totalSavedVolume.toFixed(0)} <span className="text-sm font-medium opacity-60 ml-0.5">USDC</span>
+                        {formatAmount(totalSavedVolume, { maximumFractionDigits: 0 })} <span className="text-sm font-medium opacity-60 ml-0.5">USDC</span>
                       </p>
                       <p className="text-[10px] font-semibold opacity-60 uppercase tracking-wide">{t("history.summary_volume_in")}</p>
                     </div>
@@ -280,7 +282,7 @@ const Historial = () => {
                     </div>
                     <div className="text-center">
                       <p className="text-2xl font-extrabold tabular-nums text-emerald-400 mb-1">
-                        {totalWithdrawnVolume.toFixed(0)} <span className="text-sm font-medium opacity-60 ml-0.5 text-white">USDC</span>
+                        {formatAmount(totalWithdrawnVolume, { maximumFractionDigits: 0 })} <span className="text-sm font-medium opacity-60 ml-0.5 text-white">USDC</span>
                       </p>
                       <p className="text-[10px] font-semibold opacity-60 uppercase tracking-wide">{t("history.summary_volume_out")}</p>
                     </div>

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -6,6 +6,7 @@ import { fetchContractBalance } from "../stellar/queries";
 import { recordMint } from "../stellar/activity";
 import { Shield, Wallet, Star, ChevronRight, LogOut, HelpCircle, Bell, Loader2, Award, Lock, Activity, Medal, Globe, CircleCheck } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { useFormatters } from "@/lib/format";
 import { useExportWallet } from "@privy-io/react-auth/extended-chains";
 import AppShell from "@/components/AppShell";
 import LanguageToggle from "@/components/LanguageToggle";
@@ -22,6 +23,7 @@ import { hasUsdcTrustline, buildUsdcTrustlineXdr, submitClassicXdr, ensureTestne
 const Perfil = () => {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const { formatAmount } = useFormatters();
 
   const tierFromScore = (score: number) => {
     if (score >= 1000) return 4;
@@ -490,7 +492,7 @@ const Perfil = () => {
           <div className="card-elevated p-4 text-center">
             <Wallet className="w-4 h-4 text-muted-foreground mx-auto mb-1.5" />
             <p className="text-lg font-bold text-foreground tabular-nums">
-              {loadingProfile ? "..." : onChainUsdc}
+              {loadingProfile ? "..." : formatAmount(onChainUsdc)}
             </p>
             <p className="text-[10px] text-muted-foreground font-medium uppercase tracking-wider">{t("profile.stat_savings")}</p>
           </div>
@@ -498,7 +500,7 @@ const Perfil = () => {
           <div className="card-elevated p-4 text-center border-emerald-500/20 bg-emerald-500/5">
             <Star className="w-4 h-4 text-emerald-600 mx-auto mb-1.5" />
             <p className="text-lg font-bold text-emerald-700 tabular-nums">
-              {loadingProfile ? "..." : availableCredit}
+              {loadingProfile ? "..." : formatAmount(availableCredit)}
             </p>
             <p className="text-[10px] text-emerald-600/80 font-bold uppercase tracking-wider">{t("profile.stat_credit")}</p>
             {canMintUpgrade && (
@@ -525,7 +527,7 @@ const Perfil = () => {
             </div>
             <div className="flex items-center gap-1 text-xs text-primary font-medium bg-primary/10 px-2 py-1 rounded-full">
               <Activity className="w-3 h-3" />
-              <span className="font-bold">{riskData.score.toFixed(1)} pts</span>
+              <span className="font-bold">{formatAmount(riskData.score, { minimumFractionDigits: 1, maximumFractionDigits: 1 })} pts</span>
             </div>
           </div>
           
@@ -622,7 +624,7 @@ const Perfil = () => {
               <div>
                 <p className="text-xs font-bold text-muted-foreground uppercase tracking-wider">{t("profile.stat_credit")}</p>
                 <p className="text-lg font-bold text-foreground tabular-nums">
-                  {loadingProfile ? "..." : availableCredit} <span className="text-[11px] text-muted-foreground font-normal">XLM</span>
+                  {loadingProfile ? "..." : formatAmount(availableCredit)} <span className="text-[11px] text-muted-foreground font-normal">XLM</span>
                 </p>
               </div>
               <div className="w-24">


### PR DESCRIPTION
## Summary

Localizes dates, numbers, and XLM/USDC balances so they follow the conventions of the language the user has selected, instead of always rendering in a hardcoded `es-MX` locale with `Number.toFixed(...)`.

Closes #71

## The problem

Several views formatted values locale-independently:

- Dates were hardcoded to `toLocaleDateString("es-MX", ...)`, so they never changed when the user switched to English.
- Amounts used `Number.toFixed(...)`, which always uses a `.` decimal separator and no grouping, regardless of locale.

The result: switching language localized the copy but left dates and numbers looking native-only.

## Approach

Added one small, dependency-free formatting module, `src/lib/format.ts`, built on the platform `Intl` APIs:

- `formatAmount(value, language, opts?)` — locale-aware number formatting. Formats at render time only and never mutates the value, so amounts stay exact and accurate. A non-finite input (e.g. a not-yet-loaded balance) is returned unchanged rather than showing `NaN`.
- `formatDate(value, language, opts?)` — locale-aware date/time formatting. Accepts a `Date`, ISO string, or epoch; an unparseable value is returned unchanged rather than showing `Invalid Date`.
- `useFormatters()` — a hook that binds both to the active language, so a language switch reformats every value on screen. Components call `formatAmount(value, opts?)` / `formatDate(value, opts?)` without threading the locale through.

The app's language codes (`es`, `en`) are valid BCP-47 subtags, so they map straight to `Intl`. This is deliberately not `es-MX`: pinning a single region was the original bug. With the generic codes, both dates and numbers switch — Spanish shows `1.234,56` and `15 ene`, English shows `1,234.56` and `Jan 15`. A `resolveLocale` guard falls back to the default language if an unexpected code appears, and the region can be pinned later in one place if the maintainers prefer.

The internal data model is untouched; only render-time presentation changed.

## Impacted views

- `src/components/CreditSection.tsx` — XLM credit limit, debt, and interest amounts.
- `src/components/ActivityList.tsx` — activity row date and amount.
- `src/pages/Perfil.tsx` — on-chain USDC balance, available credit (XLM), and reputation score.
- `src/pages/Historial.tsx` — month-group header, transaction row date and amount, and the two USDC volume totals.

## Before / after

| | Before (any language) | After — Spanish | After — English |
|---|---|---|---|
| Activity date | `15 ene, 14:30` (always es-MX) | `15 ene, 14:30` | `Jan 15, 2:30 PM` |
| History month header | `enero 2026` (always es-MX) | `enero 2026` | `January 2026` |
| Amount | `1234.50 XLM` (always `.`) | `1.234,50 XLM` | `1,234.50 XLM` |
| USDC volume | `1234 USDC` | `1.234 USDC` | `1,234 USDC` |

## Testing

- Added `src/lib/format.test.ts` (vitest): locale switching, fraction-digit precision, non-finite passthrough, and date parsing from `Date`/string/epoch. 9 tests pass.
- `npx tsc --noEmit`: clean.
- `npm run build`: succeeds.
- Manually compared the same screens across `es` and `en` via the in-app language toggle.
